### PR TITLE
fix: Onboarding fast fixes

### DIFF
--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -378,8 +378,7 @@ const GameList: React.FC = () => {
         </Alert>
       ) : undefined}
 
-      {/* {data.getGames.length === 0 ? ( */}
-      {true ? (
+      {data.getGames.length === 0 ? (
         <Alert severity="warning" sx={{ margin: 2 }}>
           <AlertTitle>No games found</AlertTitle>
           You will need to add some games to your library before you can launch

--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -378,7 +378,8 @@ const GameList: React.FC = () => {
         </Alert>
       ) : undefined}
 
-      {data.getGames.length === 0 ? (
+      {/* {data.getGames.length === 0 ? ( */}
+      {true ? (
         <Alert severity="warning" sx={{ margin: 2 }}>
           <AlertTitle>No games found</AlertTitle>
           You will need to add some games to your library before you can launch
@@ -395,6 +396,7 @@ const GameList: React.FC = () => {
                 startIcon={<Download />}
                 sx={{ margin: 'auto' }}
                 href="https://freedoom.github.io/download.html"
+                target="_blank"
               >
                 Download Freedoom
               </Button>
@@ -415,7 +417,7 @@ const GameList: React.FC = () => {
               </Button>
             </li>
             <li>
-              Refresh WADPunk. You can do this at any time in the settings menu.
+              Reload WADPunk. You can do this at any time in the settings menu.
               <br />
               <br />
               <Button
@@ -426,7 +428,7 @@ const GameList: React.FC = () => {
                   invalidateApolloCache()
                 }}
               >
-                Refresh
+                Reload
               </Button>
             </li>
           </ol>

--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -128,7 +128,11 @@ const SourcePortsDialog: React.FC = () => {
         </FormProvider>
       </DialogContent>
       <DialogActions>
-        <Button startIcon={<Download />} href="https://zdoom.org/downloads">
+        <Button
+          startIcon={<Download />}
+          href="https://zdoom.org/downloads"
+          target="_blank"
+        >
           Download GZDoom
         </Button>
         <Box sx={{ flexGrow: 1 }} />


### PR DESCRIPTION
Open external links in a the default browser.

Really this should be done with an event handler instead of remembering to add `_blank`, but this works for now.