### PR TITLE
feat: Store `installed_at`

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -15,6 +15,7 @@ type Game {
   play_sessions: [PlaySession!]!
 
   use_custom_config: Boolean!
+  installed_at: String!
 }
 
 type PreviousFileStateItem {

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,7 +1,4 @@
-use std::{
-  fs::{create_dir_all, File},
-  path::Path,
-};
+use std::{fs::create_dir_all, path::Path};
 
 use fs_extra::{copy_items, dir::CopyOptions};
 use tauri::api::process::Command;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,6 @@ use graphql::datasource::DataSource;
 mod database;
 mod graphql;
 mod importer;
-mod tauri_commands;
 mod tauri_helpers;
 
 fn main() {

--- a/src-tauri/src/tauri_commands/mod.rs
+++ b/src-tauri/src/tauri_commands/mod.rs
@@ -1,1 +1,0 @@
-pub mod playground;

--- a/src-tauri/src/tauri_commands/playground.rs
+++ b/src-tauri/src/tauri_commands/playground.rs
@@ -1,4 +1,0 @@
-#[tauri::command]
-pub fn greet(name: &str) -> Result<String, String> {
-  return Ok(format!("Hello, {}! You've been greeted from Rust!", name));
-}

--- a/src/games/GameDialog.tsx
+++ b/src/games/GameDialog.tsx
@@ -530,7 +530,7 @@ const GameDialogActions: React.FC<{
                 continue
               }
 
-              if (fileEntry.isIwad) {
+              if (fileEntry.isIwad && !iwad) {
                 iwad = fileEntry.absolute
               } else {
                 files.push(fileEntry.absolute)

--- a/src/games/GameDialogFileList.tsx
+++ b/src/games/GameDialogFileList.tsx
@@ -216,7 +216,6 @@ interface SortableItemProps {
 
 const SortableItem: React.FC<SortableItemProps> = (props) => {
   const theme = useTheme()
-  const canSort = !props.file.isIwad && props.file.selected
   const {
     attributes,
     listeners,
@@ -226,7 +225,6 @@ const SortableItem: React.FC<SortableItemProps> = (props) => {
     isSorting,
   } = useSortable({
     id: props.file.id,
-    disabled: !canSort,
     transition: {
       duration: theme.transitions.duration.shortest,
       easing: theme.transitions.easing.sharp,
@@ -242,7 +240,7 @@ const SortableItem: React.FC<SortableItemProps> = (props) => {
       {...listeners}
       component="div"
       sx={{
-        cursor: isSorting ? 'grabbing' : canSort ? 'grab' : undefined,
+        cursor: isSorting ? 'grabbing' : 'grab',
         transition,
         transform: transform
           ? `translate3d(${transform.x}px, ${transform.y}px, 0)`

--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -164,6 +164,13 @@ const GameList: React.FC = () => {
         )
       }
 
+      if (sortKey === 'installedAt') {
+        const valueA = new Date(a.installed_at)
+        const valueB = new Date(b.installed_at)
+
+        return valueA.valueOf() - valueB.valueOf()
+      }
+
       return 0
     })
 
@@ -290,6 +297,7 @@ const GameList: React.FC = () => {
             <MenuItem value="rating:desc">Rating</MenuItem>
             <MenuItem value="playTime:desc">Play Time</MenuItem>
             <MenuItem value="lastPlayed:desc">Last Played</MenuItem>
+            <MenuItem value="installedAt:desc">Date Installed</MenuItem>
           </TextField>
 
           <div>

--- a/src/games/operations.graphql
+++ b/src/games/operations.graphql
@@ -2,11 +2,9 @@ query getGameListQuery {
   getGames {
     id
     name
-    description
     notes
     tags
     rating
-    iwad_id
     installed_at
 
     play_sessions {

--- a/src/games/operations.graphql
+++ b/src/games/operations.graphql
@@ -7,6 +7,7 @@ query getGameListQuery {
     tags
     rating
     iwad_id
+    installed_at
 
     play_sessions {
       duration


### PR DESCRIPTION
Happens when `load_game_with_meta` is called instead of at import time, because a game can always be installed by the user copying files into their Games directory.

Currently, it's only exposed in the UI as a way to sort the games list, but the UI isn't exactly stellar at this point.

A couple of other fixes are included:

- Removed dead code
- Don't overwrite the `iwad` when starting a game

Closes #42 

## Preview

![Screenshot 2024-04-10 at 11 38 02 PM](https://github.com/mikew/wadpunk/assets/4729/e1a3b74f-f05f-4b7c-b29b-e9e62b0cadcc)


![Screenshot 2024-04-10 at 11 34 05 PM](https://github.com/mikew/wadpunk/assets/4729/48cf2673-3201-4092-9328-efec01fc536b)
