### PR TITLE
chore: Refactor `GameList`

### DIFF
--- a/src-tauri/src/graphql/datasource.rs
+++ b/src-tauri/src/graphql/datasource.rs
@@ -388,28 +388,44 @@ impl DataSource {
     game: GameInput,
   ) -> GraphQLResult<Game> {
     if let Some(mut db_game) = database::find_game_by_id(&game.id) {
-      db_game.rating = game.rating;
-      db_game.description = game.description;
-      db_game.notes = game.notes;
-      db_game.tags = game.tags;
+      if let Some(rating) = game.rating {
+        db_game.rating = Some(rating);
+      }
+      if let Some(description) = game.description {
+        db_game.description = Some(description);
+      }
+      if let Some(notes) = game.notes {
+        db_game.notes = Some(notes);
+      }
+      if let Some(tags) = game.tags {
+        db_game.tags = Some(tags);
+      }
 
-      db_game.source_port = game.source_port;
-      db_game.iwad_id = game.iwad_id;
-      db_game.extra_mod_ids = game.extra_mod_ids;
+      if let Some(source_port) = game.source_port {
+        db_game.source_port = Some(source_port);
+      }
+      if let Some(iwad_id) = game.iwad_id {
+        db_game.iwad_id = Some(iwad_id);
+      }
+      if let Some(extra_mod_ids) = game.extra_mod_ids {
+        db_game.extra_mod_ids = Some(extra_mod_ids);
+      }
 
-      db_game.use_custom_config = game.use_custom_config;
-      db_game.previous_file_state = Some(
-        game
-          .previous_file_state
-          .into_iter()
-          .flatten()
-          .map(|x| DbPreviousFileStateItem {
-            is_enabled: x.is_enabled,
-            relative: x.relative,
-            absolute: x.absolute,
-          })
-          .collect(),
-      );
+      if let Some(use_custom_config) = game.use_custom_config {
+        db_game.use_custom_config = Some(use_custom_config);
+      }
+      if let Some(previous_file_state) = game.previous_file_state {
+        db_game.previous_file_state = Some(
+          previous_file_state
+            .into_iter()
+            .map(|x| DbPreviousFileStateItem {
+              is_enabled: x.is_enabled,
+              relative: x.relative,
+              absolute: x.absolute,
+            })
+            .collect(),
+        );
+      }
 
       database::save_game(db_game.clone());
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -23,7 +23,17 @@ function App() {
     >
       <Initializer>
         <ImportDropZone>
-          <GameList />
+          <AppToolbarProvider>
+            <AppBar position="sticky">
+              <Toolbar sx={{ gap: 2 }}>
+                <AppToolbarSlot />
+                <Box flexGrow="1" />
+                <AppCogMenu />
+              </Toolbar>
+            </AppBar>
+
+            <GameList />
+          </AppToolbarProvider>
         </ImportDropZone>
 
         <SourcePortsDialog />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -39,6 +39,7 @@ function App() {
           </AppToolbarProvider>
         </ImportDropZone>
 
+        <GameDialogSuspense />
         <SourcePortsDialog />
         <UpdateNotifier />
       </Initializer>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,6 +10,7 @@ import type { SuspenseWrappedPromise } from '#src/lib/wrapPromiseForSuspense'
 import { wrapPromiseForSuspense } from '#src/lib/wrapPromiseForSuspense'
 import SourcePortsDialog from '#src/sourcePorts/SourcePortsDialog'
 
+import OnboardingAlerts from './OnboardingAlerts'
 import UpdateNotifier from './UpdateNotifier'
 
 function App() {
@@ -31,6 +32,8 @@ function App() {
                 <AppCogMenu />
               </Toolbar>
             </AppBar>
+
+            <OnboardingAlerts />
 
             <GameList />
           </AppToolbarProvider>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,9 @@
 import { useMutation } from '@apollo/client'
-import { Box, CircularProgress } from '@mui/material'
+import { AppBar, Box, CircularProgress, Toolbar } from '@mui/material'
 import type { PropsWithChildren } from 'react'
 import { Suspense, useEffect, useState } from 'react'
 
+import { GameDialogSuspense } from '#src/games/GameDialog'
 import GameList from '#src/games/GameList'
 import ImportDropZone from '#src/games/ImportDropZone'
 import { InitializeAppDocument } from '#src/graphql/operations'
@@ -10,6 +11,8 @@ import type { SuspenseWrappedPromise } from '#src/lib/wrapPromiseForSuspense'
 import { wrapPromiseForSuspense } from '#src/lib/wrapPromiseForSuspense'
 import SourcePortsDialog from '#src/sourcePorts/SourcePortsDialog'
 
+import AppCogMenu from './AppCogMenu'
+import { AppToolbarProvider, AppToolbarSlot } from './AppToolbarArea'
 import OnboardingAlerts from './OnboardingAlerts'
 import UpdateNotifier from './UpdateNotifier'
 

--- a/src/app/AppCogMenu.tsx
+++ b/src/app/AppCogMenu.tsx
@@ -1,0 +1,102 @@
+import { useSuspenseQuery } from '@apollo/client'
+import {
+  ExitToApp,
+  FolderOpen,
+  Refresh,
+  Settings,
+  Terminal,
+} from '@mui/icons-material'
+import { Divider, IconButton, ListItemIcon, Typography } from '@mui/material'
+
+import useOpenGamesFolder from '#src/games/useOpenGamesFolder'
+import { invalidateApolloCache } from '#src/graphql/graphqlClient'
+import { GetAppInfoDocument } from '#src/graphql/operations'
+import { EasyMenu, EasyMenuItem } from '#src/mui/EasyMenu'
+import { useRootDispatch } from '#src/redux/helpers'
+import actions from '#src/sourcePorts/actions'
+
+const AppCogMenu: React.FC = () => {
+  const { openGamesFolder } = useOpenGamesFolder()
+  const dispatch = useRootDispatch()
+  const { data: appInfoData } = useSuspenseQuery(GetAppInfoDocument)
+
+  return (
+    <EasyMenu
+      renderTrigger={(props) => {
+        return (
+          <IconButton {...props} edge="end">
+            <Settings />
+          </IconButton>
+        )
+      }}
+      id="settings-menu"
+      anchorOrigin={{
+        horizontal: 'right',
+        vertical: 'bottom',
+      }}
+      transformOrigin={{
+        horizontal: 'right',
+        vertical: 'top',
+      }}
+      MenuListProps={{
+        dense: true,
+      }}
+    >
+      <EasyMenuItem
+        onClickDelayed={() => {
+          dispatch(actions.toggleDialog())
+        }}
+      >
+        <ListItemIcon>
+          <Terminal fontSize="small" />
+        </ListItemIcon>
+        Source Ports
+      </EasyMenuItem>
+
+      <EasyMenuItem
+        onClickDelayed={() => {
+          openGamesFolder()
+        }}
+      >
+        <ListItemIcon>
+          <FolderOpen fontSize="small" />
+        </ListItemIcon>
+        Open Games Folder
+      </EasyMenuItem>
+
+      <Divider />
+
+      <EasyMenuItem
+        onClickDelayed={() => {
+          invalidateApolloCache()
+        }}
+      >
+        <ListItemIcon>
+          <Refresh fontSize="small" />
+        </ListItemIcon>
+        Reload
+      </EasyMenuItem>
+
+      <Divider />
+
+      <EasyMenuItem
+        onClickDelayed={() => {
+          process.exit(0)
+        }}
+      >
+        <ListItemIcon>
+          <ExitToApp fontSize="small" />
+        </ListItemIcon>
+        Exit
+      </EasyMenuItem>
+
+      <Divider />
+
+      <Typography color="text.secondary" variant="body2" textAlign="center">
+        {appInfoData.getAppInfo.name} v{appInfoData.getAppInfo.version}
+      </Typography>
+    </EasyMenu>
+  )
+}
+
+export default AppCogMenu

--- a/src/app/AppToolbarArea.tsx
+++ b/src/app/AppToolbarArea.tsx
@@ -1,0 +1,83 @@
+import { Box } from '@mui/material'
+import React, { createContext, useContext, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+export const {
+  reactContext: appToolbarContext,
+  SlotComponent: AppToolbarSlot,
+  PortalComponent: AppToolbarPortal,
+  PortalProvider: AppToolbarProvider,
+} = createSlotPortal({
+  renderSlot(props) {
+    return (
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+        ref={props.ref}
+      />
+    )
+  },
+})
+
+function createSlotPortal<T extends HTMLElement = HTMLElement>(opts: {
+  renderSlot: (props: {
+    ref: (element: T | null) => void
+  }) => React.ReactElement
+}) {
+  const reactContext = createContext<{
+    setPortalRoot: (element: T | null) => void
+    portalRoot: T | null
+  } | null>(null)
+
+  const PortalProvider: React.FC<React.PropsWithChildren> = (props) => {
+    const [portalRoot, setPortalRoot] = useState<T | null>(null)
+    const reactContextValue = useMemo(() => {
+      return {
+        setPortalRoot,
+        portalRoot,
+      }
+    }, [portalRoot])
+
+    return (
+      <reactContext.Provider value={reactContextValue}>
+        {props.children}
+      </reactContext.Provider>
+    )
+  }
+
+  const SlotComponent: React.FC = () => {
+    const context = useContext(reactContext)
+
+    if (!context) {
+      return null
+    }
+
+    return opts.renderSlot({ ref: context.setPortalRoot })
+  }
+
+  const PortalComponent: React.FC<
+    React.PropsWithChildren<{
+      portalKey: string
+    }>
+  > = (props) => {
+    const context = useContext(reactContext)
+
+    return (
+      <>
+        {context?.portalRoot
+          ? createPortal(
+              <>{props.children}</>,
+              context.portalRoot,
+              props.portalKey,
+            )
+          : undefined}
+      </>
+    )
+  }
+
+  return {
+    reactContext,
+    SlotComponent,
+    PortalComponent,
+    PortalProvider,
+  }
+}

--- a/src/games/GameFilterToolbar.tsx
+++ b/src/games/GameFilterToolbar.tsx
@@ -1,0 +1,150 @@
+import { ArrowDropDown, Search } from '@mui/icons-material'
+import {
+  Button,
+  InputAdornment,
+  ListItemIcon,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import type { SimpleFilterApi } from '@promoboxx/use-filter/dist/useSimpleFilter'
+
+import StarRating from '#src/lib/StarRating'
+import { EasyMenu, EasyMenuItem } from '#src/mui/EasyMenu'
+
+export interface GameListFilter {
+  name: string
+  rating: number
+  starRatingMode: 'at_least' | 'equal' | 'at_most'
+}
+
+const GameFilterToolbar: React.FC<{
+  filterApi: SimpleFilterApi<GameListFilter>
+}> = ({ filterApi }) => {
+  return (
+    <>
+      <TextField
+        size="small"
+        margin="none"
+        variant="standard"
+        value={filterApi.filterInfo.filter.name}
+        label="Filter ..."
+        onChange={(event) => {
+          filterApi.updateFilter({ name: event.target.value })
+        }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Search />
+            </InputAdornment>
+          ),
+        }}
+        sx={{ flex: '0 0 200px' }}
+      />
+
+      <Stack direction="column">
+        <EasyMenu
+          id="filter-star-rating-mode"
+          renderTrigger={(props) => {
+            return (
+              <Typography
+                {...props}
+                variant="overline"
+                color="text.secondary"
+                sx={{ cursor: 'pointer', lineHeight: 'initial' }}
+              >
+                {filterApi.filterInfo.filter.starRatingMode}{' '}
+                <ArrowDropDown fontSize="inherit" />
+              </Typography>
+            )
+          }}
+          MenuListProps={{
+            dense: true,
+          }}
+        >
+          <EasyMenuItem
+            selected={filterApi.filterInfo.filter.starRatingMode === 'at_most'}
+            onClickDelayed={() => {
+              filterApi.updateFilter({ starRatingMode: 'at_most' }, true)
+            }}
+          >
+            <ListItemIcon>
+              <Typography variant="body2" color="text.secondary">
+                &lt;=
+              </Typography>
+            </ListItemIcon>
+            At Most
+          </EasyMenuItem>
+
+          <EasyMenuItem
+            selected={filterApi.filterInfo.filter.starRatingMode === 'equal'}
+            onClickDelayed={() => {
+              filterApi.updateFilter({ starRatingMode: 'equal' }, true)
+            }}
+          >
+            <ListItemIcon>
+              <Typography variant="body2" color="text.secondary">
+                =
+              </Typography>
+            </ListItemIcon>
+            Exactly
+          </EasyMenuItem>
+
+          <EasyMenuItem
+            selected={filterApi.filterInfo.filter.starRatingMode === 'at_least'}
+            onClickDelayed={() => {
+              filterApi.updateFilter({ starRatingMode: 'at_least' }, true)
+            }}
+          >
+            <ListItemIcon>
+              <Typography variant="body2" color="text.secondary">
+                &gt;=
+              </Typography>
+            </ListItemIcon>
+            At Least
+          </EasyMenuItem>
+        </EasyMenu>
+
+        <StarRating
+          value={filterApi.debouncedFilterInfo.filter.rating}
+          onChange={(value) => {
+            filterApi.updateFilter({ rating: value }, true)
+          }}
+        />
+      </Stack>
+
+      <TextField
+        select
+        size="small"
+        margin="none"
+        variant="standard"
+        label="Sort By ..."
+        value={filterApi.debouncedFilterInfo.sort}
+        onChange={(event) => {
+          filterApi.setSort(event.target.value, true)
+        }}
+        sx={{ flex: '0 0 200px' }}
+      >
+        <MenuItem value="name:asc">Name</MenuItem>
+        <MenuItem value="rating:desc">Rating</MenuItem>
+        <MenuItem value="playTime:desc">Play Time</MenuItem>
+        <MenuItem value="lastPlayed:desc">Last Played</MenuItem>
+        <MenuItem value="installedAt:desc">Date Installed</MenuItem>
+      </TextField>
+
+      <div>
+        <Button
+          size="small"
+          onClick={() => {
+            filterApi.resetFilter(true)
+          }}
+        >
+          Clear
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export default GameFilterToolbar

--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -1,64 +1,28 @@
 import { useMutation, useSuspenseQuery } from '@apollo/client'
-import {
-  ArrowDropDown,
-  ExitToApp,
-  Refresh,
-  Search,
-  Settings,
-  Terminal,
-} from '@mui/icons-material'
 import FolderOpen from '@mui/icons-material/FolderOpen'
 import {
-  AppBar,
-  Box,
-  Button,
   Chip,
-  Divider,
   IconButton,
-  InputAdornment,
   List,
   ListItem,
   ListItemButton,
-  ListItemIcon,
   ListItemText,
-  MenuItem,
   Stack,
-  TextField,
-  Toolbar,
-  Typography,
 } from '@mui/material'
 import useSimpleFilter from '@promoboxx/use-filter/dist/useSimpleFilter'
-import { process } from '@tauri-apps/api'
-import { enqueueSnackbar } from 'notistack'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
-import OnboardingAlerts from '#src/app/OnboardingAlerts'
-import { invalidateApolloCache } from '#src/graphql/graphqlClient'
-import type { GetGameListQueryQuery } from '#src/graphql/operations'
+import { AppToolbarPortal } from '#src/app/AppToolbarArea'
+import * as games from '#src/games/redux'
 import {
-  GetAppInfoDocument,
   GetGameListQueryDocument,
-  OpenGamesFolderDocument,
   SetRatingDocument,
 } from '#src/graphql/operations'
 import pathWithoutExtension from '#src/lib/pathWithoutExtension'
 import StarRating from '#src/lib/StarRating'
-import { EasyMenu, EasyMenuItem } from '#src/mui/EasyMenu'
 import { useRootDispatch } from '#src/redux/helpers'
-import actions from '#src/sourcePorts/actions'
 
 import calculateGamePlayTime from './calculateGamePlayTime'
-import GameDialog from './GameDialog'
-
-type ArrayItemType<T> = T extends Array<infer A> ? A : never
-
-export type GameListGame = ArrayItemType<GetGameListQueryQuery['getGames']>
-
-interface GameListFilter {
-  name: string
-  rating: number
-  starRatingMode: 'at_least' | 'equal' | 'at_most'
-}
 import type { GameListFilter } from './GameFilterToolbar'
 import GameFilterToolbar from './GameFilterToolbar'
 import useOpenGamesFolder from './useOpenGamesFolder'
@@ -68,7 +32,7 @@ const GameList: React.FC = () => {
   const dispatch = useRootDispatch()
 
   const [setRating] = useMutation(SetRatingDocument)
-  const { data: appInfoData } = useSuspenseQuery(GetAppInfoDocument)
+  const { openGamesFolder } = useOpenGamesFolder()
 
   const filterApi = useSimpleFilter<GameListFilter>('GameList', {
     defaultFilterInfo: {

--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -171,8 +171,6 @@ const GameList: React.FC = () => {
 
   return (
     <>
-
-      <OnboardingAlerts />
       <AppToolbarPortal portalKey="GameFilterToolbar">
         <GameFilterToolbar filterApi={filterApi} />
       </AppToolbarPortal>

--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -68,7 +68,6 @@ const GameList: React.FC = () => {
   const dispatch = useRootDispatch()
 
   const [setRating] = useMutation(SetRatingDocument)
-  const [selectedId, setSelectedId] = useState<GameListGame['id']>()
   const { data: appInfoData } = useSuspenseQuery(GetAppInfoDocument)
 
   const filterApi = useSimpleFilter<GameListFilter>('GameList', {
@@ -191,7 +190,7 @@ const GameList: React.FC = () => {
               <ListItemButton
                 disableRipple
                 onClick={() => {
-                  setSelectedId(x.id)
+                  dispatch(games.actions.setSelectedId(x.id))
                 }}
               >
                 <ListItemText
@@ -252,14 +251,6 @@ const GameList: React.FC = () => {
           )
         })}
       </List>
-
-      {selectedId ? (
-        <GameDialog
-          open={!!selectedId}
-          gameId={selectedId}
-          onClose={() => setSelectedId(undefined)}
-        />
-      ) : undefined}
     </>
   )
 }

--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -59,6 +59,8 @@ interface GameListFilter {
   rating: number
   starRatingMode: 'at_least' | 'equal' | 'at_most'
 }
+import type { GameListFilter } from './GameFilterToolbar'
+import GameFilterToolbar from './GameFilterToolbar'
 import useOpenGamesFolder from './useOpenGamesFolder'
 
 const GameList: React.FC = () => {
@@ -69,13 +71,7 @@ const GameList: React.FC = () => {
   const [selectedId, setSelectedId] = useState<GameListGame['id']>()
   const { data: appInfoData } = useSuspenseQuery(GetAppInfoDocument)
 
-  const {
-    debouncedFilterInfo,
-    filterInfo,
-    updateFilter,
-    resetFilter,
-    setSort,
-  } = useSimpleFilter<GameListFilter>('GameList', {
+  const filterApi = useSimpleFilter<GameListFilter>('GameList', {
     defaultFilterInfo: {
       filter: {
         name: '',
@@ -86,6 +82,7 @@ const GameList: React.FC = () => {
     },
   })
 
+  const { debouncedFilterInfo } = filterApi
 
   const filtered = useMemo(() => {
     const filtered = data.getGames.filter((x) => {
@@ -174,134 +171,11 @@ const GameList: React.FC = () => {
 
   return (
     <>
-      <AppBar position="sticky">
-        <Toolbar sx={{ gap: 2 }}>
-          <TextField
-            size="small"
-            margin="none"
-            variant="standard"
-            value={filterInfo.filter.name}
-            label="Filter ..."
-            onChange={(event) => {
-              updateFilter({ name: event.target.value })
-            }}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Search />
-                </InputAdornment>
-              ),
-            }}
-            sx={{ flex: '0 0 200px' }}
-          />
-
-          <Stack direction="column">
-            <EasyMenu
-              id="filter-star-rating-mode"
-              renderTrigger={(props) => {
-                return (
-                  <Typography
-                    {...props}
-                    variant="overline"
-                    color="text.secondary"
-                    sx={{ cursor: 'pointer', lineHeight: 'initial' }}
-                  >
-                    {filterInfo.filter.starRatingMode}{' '}
-                    <ArrowDropDown fontSize="inherit" />
-                  </Typography>
-                )
-              }}
-              MenuListProps={{
-                dense: true,
-              }}
-            >
-              <EasyMenuItem
-                selected={filterInfo.filter.starRatingMode === 'at_most'}
-                onClickDelayed={() => {
-                  updateFilter({ starRatingMode: 'at_most' }, true)
-                }}
-              >
-                <ListItemIcon>
-                  <Typography variant="body2" color="text.secondary">
-                    &lt;=
-                  </Typography>
-                </ListItemIcon>
-                At Most
-              </EasyMenuItem>
-
-              <EasyMenuItem
-                selected={filterInfo.filter.starRatingMode === 'equal'}
-                onClickDelayed={() => {
-                  updateFilter({ starRatingMode: 'equal' }, true)
-                }}
-              >
-                <ListItemIcon>
-                  <Typography variant="body2" color="text.secondary">
-                    =
-                  </Typography>
-                </ListItemIcon>
-                Exactly
-              </EasyMenuItem>
-
-              <EasyMenuItem
-                selected={filterInfo.filter.starRatingMode === 'at_least'}
-                onClickDelayed={() => {
-                  updateFilter({ starRatingMode: 'at_least' }, true)
-                }}
-              >
-                <ListItemIcon>
-                  <Typography variant="body2" color="text.secondary">
-                    &gt;=
-                  </Typography>
-                </ListItemIcon>
-                At Least
-              </EasyMenuItem>
-            </EasyMenu>
-
-            <StarRating
-              value={debouncedFilterInfo.filter.rating}
-              onChange={(value) => {
-                updateFilter({ rating: value }, true)
-              }}
-            />
-          </Stack>
-
-          <TextField
-            select
-            size="small"
-            margin="none"
-            variant="standard"
-            label="Sort By ..."
-            value={debouncedFilterInfo.sort}
-            onChange={(event) => {
-              setSort(event.target.value, true)
-            }}
-            sx={{ flex: '0 0 200px' }}
-          >
-            <MenuItem value="name:asc">Name</MenuItem>
-            <MenuItem value="rating:desc">Rating</MenuItem>
-            <MenuItem value="playTime:desc">Play Time</MenuItem>
-            <MenuItem value="lastPlayed:desc">Last Played</MenuItem>
-            <MenuItem value="installedAt:desc">Date Installed</MenuItem>
-          </TextField>
-
-          <div>
-            <Button
-              size="small"
-              onClick={() => {
-                resetFilter(true)
-              }}
-            >
-              Clear
-            </Button>
-          </div>
-
-          <Box flexGrow="1" />
-
-        </Toolbar>
-      </AppBar>
 
       <OnboardingAlerts />
+      <AppToolbarPortal portalKey="GameFilterToolbar">
+        <GameFilterToolbar filterApi={filterApi} />
+      </AppToolbarPortal>
 
       <List disablePadding dense>
         {filtered.map((x) => {

--- a/src/games/GameList.tsx
+++ b/src/games/GameList.tsx
@@ -59,12 +59,12 @@ interface GameListFilter {
   rating: number
   starRatingMode: 'at_least' | 'equal' | 'at_most'
 }
+import useOpenGamesFolder from './useOpenGamesFolder'
 
 const GameList: React.FC = () => {
   const { data } = useSuspenseQuery(GetGameListQueryDocument)
   const dispatch = useRootDispatch()
 
-  const [openGamesFolderMutation] = useMutation(OpenGamesFolderDocument)
   const [setRating] = useMutation(SetRatingDocument)
   const [selectedId, setSelectedId] = useState<GameListGame['id']>()
   const { data: appInfoData } = useSuspenseQuery(GetAppInfoDocument)
@@ -86,21 +86,6 @@ const GameList: React.FC = () => {
     },
   })
 
-  async function openGamesFolder(game_id?: string) {
-    try {
-      const response = await openGamesFolderMutation({
-        variables: {
-          game_id,
-        },
-      })
-
-      if (!response.data?.openGamesFolder) {
-        enqueueSnackbar('Could not open folder', { variant: 'error' })
-      }
-    } catch (err) {
-      console.error(err)
-    }
-  }
 
   const filtered = useMemo(() => {
     const filtered = data.getGames.filter((x) => {
@@ -313,81 +298,6 @@ const GameList: React.FC = () => {
 
           <Box flexGrow="1" />
 
-          <EasyMenu
-            renderTrigger={(props) => {
-              return (
-                <IconButton {...props} edge="end">
-                  <Settings />
-                </IconButton>
-              )
-            }}
-            id="settings-menu"
-            anchorOrigin={{
-              horizontal: 'right',
-              vertical: 'bottom',
-            }}
-            transformOrigin={{
-              horizontal: 'right',
-              vertical: 'top',
-            }}
-            MenuListProps={{
-              dense: true,
-            }}
-          >
-            <EasyMenuItem
-              onClickDelayed={() => {
-                openGamesFolder()
-              }}
-            >
-              <ListItemIcon>
-                <FolderOpen fontSize="small" />
-              </ListItemIcon>
-              Open Games Folder
-            </EasyMenuItem>
-
-            <EasyMenuItem
-              onClickDelayed={() => {
-                dispatch(actions.toggleDialog())
-              }}
-            >
-              <ListItemIcon>
-                <Terminal fontSize="small" />
-              </ListItemIcon>
-              Source Ports
-            </EasyMenuItem>
-
-            <EasyMenuItem
-              onClickDelayed={() => {
-                invalidateApolloCache()
-              }}
-            >
-              <ListItemIcon>
-                <Refresh fontSize="small" />
-              </ListItemIcon>
-              Reload
-            </EasyMenuItem>
-
-            <EasyMenuItem
-              onClickDelayed={() => {
-                process.exit(0)
-              }}
-            >
-              <ListItemIcon>
-                <ExitToApp fontSize="small" />
-              </ListItemIcon>
-              Exit
-            </EasyMenuItem>
-
-            <Divider />
-
-            <Typography
-              color="text.secondary"
-              variant="body2"
-              textAlign="center"
-            >
-              {appInfoData.getAppInfo.name} v{appInfoData.getAppInfo.version}
-            </Typography>
-          </EasyMenu>
         </Toolbar>
       </AppBar>
 

--- a/src/games/redux.ts
+++ b/src/games/redux.ts
@@ -1,0 +1,20 @@
+import { createActions, createReducer } from 'redux-easy-mode'
+
+import type { Game } from '#src/graphql/types'
+
+export const actions = createActions('games', {
+  setSelectedId: (id: Game['id'] | undefined) => ({ id }),
+})
+
+export interface State {
+  selectedId?: Game['id']
+}
+
+export const initialState: State = {}
+
+export const reducer = createReducer(initialState, (builder) => {
+  builder.addHandler(actions.setSelectedId, (state, action) => ({
+    ...state,
+    selectedId: action.payload.id,
+  }))
+})

--- a/src/games/types.ts
+++ b/src/games/types.ts
@@ -1,0 +1,7 @@
+import type {
+  GetGameDialogFieldsQuery,
+  GetGameListQueryQuery,
+} from '#src/graphql/operations'
+
+export type GameListGame = ArrayItemType<GetGameListQueryQuery['getGames']>
+export type GameDialogGame = GetGameDialogFieldsQuery['getGame']

--- a/src/games/useOpenGamesFolder.ts
+++ b/src/games/useOpenGamesFolder.ts
@@ -1,0 +1,34 @@
+import { useMutation } from '@apollo/client'
+import { enqueueSnackbar } from 'notistack'
+import { useCallback } from 'react'
+
+import { OpenGamesFolderDocument } from '#src/graphql/operations'
+
+function useOpenGamesFolder() {
+  const [openGamesFolderMutation] = useMutation(OpenGamesFolderDocument)
+
+  const openGamesFolder = useCallback(
+    async (game_id?: string) => {
+      try {
+        const response = await openGamesFolderMutation({
+          variables: {
+            game_id,
+          },
+        })
+
+        if (!response.data?.openGamesFolder) {
+          enqueueSnackbar('Could not open folder', { variant: 'error' })
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    },
+    [openGamesFolderMutation],
+  )
+
+  return {
+    openGamesFolder,
+  }
+}
+
+export default useOpenGamesFolder

--- a/src/graphql/graphqlClient.ts
+++ b/src/graphql/graphqlClient.ts
@@ -30,6 +30,10 @@ export const invalidateApolloQuery = (queryNames: (keyof Query)[]) => {
 
 export const invalidateApolloCache = () => {
   apolloCache.reset()
+
+  // See note towards the end of
+  // https://www.apollographql.com/docs/react/caching/garbage-collection/#cacheevict
+  apolloCache.gc()
 }
 
 export default graphqlClient

--- a/src/lib/typescript-helpers/ArrayItemType.d.ts
+++ b/src/lib/typescript-helpers/ArrayItemType.d.ts
@@ -1,0 +1,1 @@
+type ArrayItemType<T> = T extends Array<infer A> ? A : never

--- a/src/redux/rootReducer.ts
+++ b/src/redux/rootReducer.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux'
 
+import * as games from '#src/games/redux'
 import * as sourcePorts from '#src/sourcePorts/reducer'
 
 const rootReducer = combineReducers({
   sourcePorts: sourcePorts.reducer,
+  games: games.reducer,
 })
 
 export default rootReducer


### PR DESCRIPTION
This brings along some much needed organization:

- `GameDialog`/`GameDialogInner` are now `GameDialogSuspense`/`GameDialog`, and driven by redux
- `App.tsx` now owns the menu and AppBar area, while also rendering `OnboardingAlerts` and `GameDialogSuspense`
- `GameList` is now literally the game ... list, while also rendering the toolbar
  - The toolbar itself is rendered via what I've dubbed a "slot portal": a way to for one component to render something in another react component elsewhere in the tree. This is a small wrapper around context + a ref, inspired by work from @smartbadger
  
    This lets `GameList` continue to manage its filter api and fields like it always has, but the fields themselves are rendered somewhere totally different
- Some random typescript types are now moved to `${feature}/types.ts`, or `lib/typescript-helpers/...`

And some more bug fixes:

- Call `cache.gc()` after resetting apollo cache
- Don't save missing fields in `updateGame` mutation