### PR TITLE
fix: Exit button

### DIFF
--- a/src/app/AppCogMenu.tsx
+++ b/src/app/AppCogMenu.tsx
@@ -7,6 +7,7 @@ import {
   Terminal,
 } from '@mui/icons-material'
 import { Divider, IconButton, ListItemIcon, Typography } from '@mui/material'
+import { process } from '@tauri-apps/api'
 
 import useOpenGamesFolder from '#src/games/useOpenGamesFolder'
 import { invalidateApolloCache } from '#src/graphql/graphqlClient'


### PR DESCRIPTION
Missed in https://github.com/mikew/wadpunk/pull/62 because `process` is a valid global in node