### PR TITLE
feat: Better support for other Source Ports

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -54,7 +54,6 @@ type AppInfo {
 type KnownSourcePort {
   id: ID!
   name: String!
-  description: String!
   supports_custom_config: Boolean!
   supports_save_dir: Boolean!
   example_command: [String!]!

--- a/schema.graphql
+++ b/schema.graphql
@@ -42,12 +42,21 @@ type GameFileEntry {
 type SourcePort {
   id: ID!
   command: [String!]!
+  known_source_port_id: ID!
   is_default: Boolean!
 }
 
 type AppInfo {
   name: String!
   version: String!
+}
+
+type KnownSourcePort {
+  id: ID!
+  name: String!
+  description: String!
+  supports_custom_config: Boolean!
+  supports_save_dir: Boolean!
 }
 
 type Query {
@@ -60,6 +69,8 @@ type Query {
   getAppSettings: AppSettings!
 
   getAppInfo: AppInfo!
+
+  getKnownSourcePorts: [KnownSourcePort!]!
 }
 
 input PreviousFileStateItemInput {
@@ -87,6 +98,7 @@ input GameInput {
 input CreateSourcePortInput {
   id: ID!
   command: [String!]!
+  known_source_port_id: ID!
 
   # TODO Should this be a separate mutation? The field probably won't be in the
   # ui for editing source ports, will probably be in the list itself.
@@ -96,6 +108,7 @@ input CreateSourcePortInput {
 input UpdateSourcePortInput {
   id: ID!
   command: [String!]!
+  known_source_port_id: ID!
 
   # TODO Should this be a separate mutation? The field probably won't be in the
   # ui for editing source ports, will probably be in the list itself.

--- a/schema.graphql
+++ b/schema.graphql
@@ -57,6 +57,7 @@ type KnownSourcePort {
   description: String!
   supports_custom_config: Boolean!
   supports_save_dir: Boolean!
+  example_command: [String!]!
 }
 
 type Query {

--- a/schema.graphql
+++ b/schema.graphql
@@ -58,6 +58,8 @@ type KnownSourcePort {
   supports_custom_config: Boolean!
   supports_save_dir: Boolean!
   example_command: [String!]!
+  home_page_url: String!
+  download_page_url: String!
 }
 
 type Query {

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -277,6 +277,7 @@ pub struct DbPlaySessionEntry {
 pub struct DbSourcePort {
   pub id: Option<String>,
   pub command: Option<Vec<String>>,
+  pub known_source_port_id: Option<String>,
 }
 
 fn recurse_disk_entry(dir: DiskEntry, files: &mut Vec<String>) {
@@ -298,6 +299,10 @@ impl DbSourcePort {
     SourcePort {
       id: self.id.clone().unwrap(),
       command: self.command.clone().unwrap_or_default(),
+      known_source_port_id: self
+        .known_source_port_id
+        .clone()
+        .unwrap_or("gzdoom".to_string()),
       is_default: false,
     }
   }

--- a/src-tauri/src/known_source_ports.rs
+++ b/src-tauri/src/known_source_ports.rs
@@ -57,6 +57,31 @@ impl DbKnownSourcePort {
     }
   }
 
+  pub fn home_page_url(&self) -> String {
+    match self {
+      Self::GZDoom => "https://zdoom.org/".to_string(),
+      Self::EternityEngine => "https://eternity.youfailit.net/wiki/Eternity_Engine".to_string(),
+      Self::ChocolateDoom => "https://www.chocolate-doom.org/".to_string(),
+      Self::DSDA => "https://github.com/kraflab/dsda-doom".to_string(),
+      Self::Woof => "https://github.com/fabiangreffrath/woof".to_string(),
+    }
+  }
+
+  pub fn download_page_url(&self) -> String {
+    match self {
+      Self::GZDoom => "https://github.com/ZDoom/gzdoom/releases".to_string(),
+      Self::EternityEngine => {
+        "https://github.com/team-eternity/eternity/releases/latest".to_string()
+      }
+      Self::ChocolateDoom => "https://www.chocolate-doom.org/wiki/index.php/Downloads".to_string(),
+      Self::DSDA => {
+        "https://drive.google.com/drive/folders/1KMU1dY0HZrY5h2EyPzxxXuyH8DunAJV_?usp=sharing"
+          .to_string()
+      }
+      Self::Woof => "https://github.com/fabiangreffrath/woof/releases/latest".to_string(),
+    }
+  }
+
   pub fn to_known_source_port(&self) -> KnownSourcePort {
     KnownSourcePort {
       id: self.id(),
@@ -64,6 +89,8 @@ impl DbKnownSourcePort {
       description: "".to_string(),
       supports_custom_config: self.supports_custom_config(),
       supports_save_dir: self.supports_save_dir(),
+      home_page_url: self.home_page_url(),
+      download_page_url: self.download_page_url(),
       example_command: self.build_command(&BuildCommandArgs {
         executable: self.id().to_string(),
         iwad: "doom2.iwad".to_string(),

--- a/src-tauri/src/known_source_ports.rs
+++ b/src-tauri/src/known_source_ports.rs
@@ -94,7 +94,7 @@ impl DbKnownSourcePort {
       example_command: self.build_command(&BuildCommandArgs {
         executable: self.id().to_string(),
         iwad: "doom2.iwad".to_string(),
-        files: vec!["example.wad".to_string()],
+        files: vec!["example1.wad".to_string(), "example2.wad".to_string()],
         use_custom_config: true,
         game_id: "doom2".to_string(),
       }),

--- a/src-tauri/src/known_source_ports.rs
+++ b/src-tauri/src/known_source_ports.rs
@@ -64,6 +64,13 @@ impl DbKnownSourcePort {
       description: "".to_string(),
       supports_custom_config: self.supports_custom_config(),
       supports_save_dir: self.supports_save_dir(),
+      example_command: self.build_command(&BuildCommandArgs {
+        executable: self.id().to_string(),
+        iwad: "doom2.iwad".to_string(),
+        files: vec!["example.wad".to_string()],
+        use_custom_config: true,
+        game_id: "doom2".to_string(),
+      }),
     }
   }
 

--- a/src-tauri/src/known_source_ports.rs
+++ b/src-tauri/src/known_source_ports.rs
@@ -1,0 +1,150 @@
+use crate::{database, graphql::generated::KnownSourcePort};
+
+pub struct BuildCommandArgs {
+  pub executable: String,
+  pub iwad: String,
+  pub files: Vec<String>,
+  pub use_custom_config: bool,
+  pub game_id: String,
+}
+
+pub enum DbKnownSourcePort {
+  GZDoom,
+  EternityEngine,
+  ChocolateDoom,
+}
+
+impl DbKnownSourcePort {
+  pub fn id(&self) -> String {
+    match self {
+      Self::GZDoom => "gzdoom".to_string(),
+      Self::EternityEngine => "eternity".to_string(),
+      Self::ChocolateDoom => "chocolate-doom".to_string(),
+    }
+  }
+
+  pub fn name(&self) -> String {
+    match self {
+      Self::GZDoom => "GZDoom".to_string(),
+      Self::EternityEngine => "Eternity Engine".to_string(),
+      Self::ChocolateDoom => "Chocolate Doom".to_string(),
+    }
+  }
+
+  pub fn supports_custom_config(&self) -> bool {
+    match self {
+      Self::GZDoom => true,
+      Self::EternityEngine => true,
+      Self::ChocolateDoom => true,
+    }
+  }
+
+  pub fn supports_save_dir(&self) -> bool {
+    match self {
+      Self::GZDoom => true,
+      Self::EternityEngine => true,
+      Self::ChocolateDoom => true,
+    }
+  }
+
+  pub fn to_known_source_port(&self) -> KnownSourcePort {
+    KnownSourcePort {
+      id: self.id(),
+      name: self.name(),
+      description: "".to_string(),
+      supports_custom_config: self.supports_custom_config(),
+      supports_save_dir: self.supports_save_dir(),
+    }
+  }
+
+  pub fn build_command(&self, args: &BuildCommandArgs) -> Vec<String> {
+    let mut command = vec![args.executable.clone()];
+
+    if args.use_custom_config {
+      let config_path = database::get_meta_directory()
+        .join(database::normalize_name_from_id(&args.game_id))
+        .join("config.ini")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+      match self {
+        Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom => {
+          command.push("-config".to_string());
+          command.push(config_path);
+        }
+      }
+    }
+
+    let save_dir = database::get_meta_directory()
+      .join(database::normalize_name_from_id(&args.game_id))
+      .join("saves")
+      .to_str()
+      .unwrap()
+      .to_string();
+    match self {
+      Self::GZDoom | Self::ChocolateDoom => {
+        command.push("-savedir".to_string());
+        command.push(save_dir);
+      }
+      Self::EternityEngine => {
+        command.push("-save".to_string());
+        command.push(save_dir);
+      }
+    }
+
+    command.push("-iwad".to_string());
+    command.push(args.iwad.clone());
+
+    for file in &args.files {
+      // If the file ends with .deh, add `-deh <file>`, if the file ends with
+      // .bex, add `-bex <file>`, otherwise just add `-file <file>`
+      if file.ends_with(".deh") {
+        match self {
+          Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom => {
+            command.push("-deh".to_string());
+            command.push(file.clone());
+          }
+        }
+      } else if file.ends_with(".bex") {
+        match self {
+          Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom => {
+            command.push("-deh".to_string());
+            command.push(file.clone());
+          }
+        }
+      } else {
+        match self {
+          Self::GZDoom | Self::EternityEngine => {
+            command.push("-file".to_string());
+            command.push(file.clone());
+          }
+          Self::ChocolateDoom => {
+            command.push("-merge".to_string());
+            command.push(file.clone());
+          }
+        }
+      }
+    }
+
+    command
+  }
+}
+
+pub fn get_all_known_source_ports() -> Vec<DbKnownSourcePort> {
+  vec![
+    DbKnownSourcePort::GZDoom,
+    DbKnownSourcePort::EternityEngine,
+    DbKnownSourcePort::ChocolateDoom,
+  ]
+}
+
+pub fn find_known_source_port_from_id(id: &str) -> DbKnownSourcePort {
+  for source_port in get_all_known_source_ports() {
+    if source_port.id() == id {
+      return source_port;
+    }
+  }
+
+  DbKnownSourcePort::GZDoom
+}

--- a/src-tauri/src/known_source_ports.rs
+++ b/src-tauri/src/known_source_ports.rs
@@ -12,6 +12,8 @@ pub enum DbKnownSourcePort {
   GZDoom,
   EternityEngine,
   ChocolateDoom,
+  DSDA,
+  Woof,
 }
 
 impl DbKnownSourcePort {
@@ -20,6 +22,8 @@ impl DbKnownSourcePort {
       Self::GZDoom => "gzdoom".to_string(),
       Self::EternityEngine => "eternity".to_string(),
       Self::ChocolateDoom => "chocolate-doom".to_string(),
+      Self::DSDA => "dsda".to_string(),
+      Self::Woof => "woof".to_string(),
     }
   }
 
@@ -28,6 +32,8 @@ impl DbKnownSourcePort {
       Self::GZDoom => "GZDoom".to_string(),
       Self::EternityEngine => "Eternity Engine".to_string(),
       Self::ChocolateDoom => "Chocolate Doom".to_string(),
+      Self::DSDA => "DSDA".to_string(),
+      Self::Woof => "Woof".to_string(),
     }
   }
 
@@ -36,6 +42,8 @@ impl DbKnownSourcePort {
       Self::GZDoom => true,
       Self::EternityEngine => true,
       Self::ChocolateDoom => true,
+      Self::DSDA => true,
+      Self::Woof => true,
     }
   }
 
@@ -44,6 +52,8 @@ impl DbKnownSourcePort {
       Self::GZDoom => true,
       Self::EternityEngine => true,
       Self::ChocolateDoom => true,
+      Self::DSDA => true,
+      Self::Woof => true,
     }
   }
 
@@ -69,7 +79,7 @@ impl DbKnownSourcePort {
         .to_string();
 
       match self {
-        Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom => {
+        Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom | Self::DSDA | Self::Woof => {
           command.push("-config".to_string());
           command.push(config_path);
         }
@@ -87,7 +97,7 @@ impl DbKnownSourcePort {
         command.push("-savedir".to_string());
         command.push(save_dir);
       }
-      Self::EternityEngine => {
+      Self::EternityEngine | Self::DSDA | Self::Woof => {
         command.push("-save".to_string());
         command.push(save_dir);
       }
@@ -101,21 +111,21 @@ impl DbKnownSourcePort {
       // .bex, add `-bex <file>`, otherwise just add `-file <file>`
       if file.ends_with(".deh") {
         match self {
-          Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom => {
+          Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom | Self::DSDA | Self::Woof => {
             command.push("-deh".to_string());
             command.push(file.clone());
           }
         }
       } else if file.ends_with(".bex") {
         match self {
-          Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom => {
+          Self::GZDoom | Self::EternityEngine | Self::ChocolateDoom | Self::DSDA | Self::Woof => {
             command.push("-deh".to_string());
             command.push(file.clone());
           }
         }
       } else {
         match self {
-          Self::GZDoom | Self::EternityEngine => {
+          Self::GZDoom | Self::EternityEngine | Self::DSDA | Self::Woof => {
             command.push("-file".to_string());
             command.push(file.clone());
           }
@@ -136,6 +146,8 @@ pub fn get_all_known_source_ports() -> Vec<DbKnownSourcePort> {
     DbKnownSourcePort::GZDoom,
     DbKnownSourcePort::EternityEngine,
     DbKnownSourcePort::ChocolateDoom,
+    DbKnownSourcePort::DSDA,
+    DbKnownSourcePort::Woof,
   ]
 }
 

--- a/src-tauri/src/known_source_ports.rs
+++ b/src-tauri/src/known_source_ports.rs
@@ -86,7 +86,6 @@ impl DbKnownSourcePort {
     KnownSourcePort {
       id: self.id(),
       name: self.name(),
-      description: "".to_string(),
       supports_custom_config: self.supports_custom_config(),
       supports_save_dir: self.supports_save_dir(),
       home_page_url: self.home_page_url(),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use graphql::datasource::DataSource;
 mod database;
 mod graphql;
 mod importer;
+mod known_source_ports;
 mod tauri_helpers;
 
 fn main() {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client'
 import { AppBar, Box, Toolbar } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 
 import { GameDialogSuspense } from '#src/games/GameDialog'
 import GameList from '#src/games/GameList'
@@ -61,4 +61,4 @@ function Initializer(props: React.PropsWithChildren) {
   )
 }
 
-export default App
+export default memo(App)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,7 @@ import ImportDropZone from '#src/games/ImportDropZone'
 import { InitializeAppDocument } from '#src/graphql/operations'
 import type { SuspenseWrappedPromise } from '#src/lib/wrapPromiseForSuspense'
 import { wrapPromiseForSuspense } from '#src/lib/wrapPromiseForSuspense'
+import KnownSourcePortsDialog from '#src/sourcePorts/KnownSourcePortsDialog'
 import SourcePortsDialog from '#src/sourcePorts/SourcePortsDialog'
 
 import AppCogMenu from './AppCogMenu'
@@ -37,7 +38,10 @@ function App() {
       </ImportDropZone>
 
       <GameDialogSuspense />
+
       <SourcePortsDialog />
+      <KnownSourcePortsDialog />
+
       <UpdateNotifier />
     </Initializer>
   )

--- a/src/app/OnboardingAlerts.tsx
+++ b/src/app/OnboardingAlerts.tsx
@@ -6,11 +6,11 @@ import { GetGameListQueryDocument } from '#src/graphql/operations'
 import { useI18nContext } from '#src/i18n/lib/i18nContext'
 import { useRootDispatch } from '#src/redux/helpers'
 import actions from '#src/sourcePorts/actions'
-import useAllSourcePorts from '#src/sourcePorts/useAllSourcePorts'
+import { useSourcePortsContext } from '#src/sourcePorts/sourcePortsContext'
 
 const OnboardingAlerts: React.FC = () => {
   const { data } = useSuspenseQuery(GetGameListQueryDocument)
-  const { sourcePorts } = useAllSourcePorts()
+  const { sourcePorts } = useSourcePortsContext()
   const dispatch = useRootDispatch()
   const { t } = useI18nContext()
 

--- a/src/games/GameDialog.tsx
+++ b/src/games/GameDialog.tsx
@@ -49,7 +49,7 @@ import DelayedOnCloseDialog, {
 } from '#src/mui/DelayedOnCloseDialog'
 import ReactHookFormTextField from '#src/react-hook-form/ReactHookFormTextField'
 import { useRootDispatch, useRootSelector } from '#src/redux/helpers'
-import useAllSourcePorts from '#src/sourcePorts/useAllSourcePorts'
+import { useSourcePortsContext } from '#src/sourcePorts/sourcePortsContext'
 
 import GameDialogFileList from './GameDialogFileList'
 import {
@@ -117,7 +117,7 @@ const GameDialog: React.FC<{
     },
   })
 
-  const { sourcePorts, defaultSourcePort } = useAllSourcePorts()
+  const { sourcePorts, defaultSourcePort } = useSourcePortsContext()
 
   const [updateGame] = useMutation(UpdateGameDocument)
 
@@ -487,7 +487,7 @@ const GameDialogActions: React.FC<{
   const { files: allFiles } = useGameFileListContext()
   const triggerClose = useDelayedOnCloseDialogTriggerClose()
   const formState = useFormState()
-  const { findSourcePortById } = useAllSourcePorts()
+  const { findSourcePortById } = useSourcePortsContext()
   const { t } = useI18nContext()
 
   return (

--- a/src/i18n/I18nLoader.tsx
+++ b/src/i18n/I18nLoader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 
 import {
   wrapPromiseForSuspense,
@@ -53,4 +53,4 @@ const I18nLoader: React.FC<React.PropsWithChildren> = (props) => {
   )
 }
 
-export default I18nLoader
+export default memo(I18nLoader)

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -111,6 +111,7 @@
     "default": "Default ({{sourcePort}})",
     "addNew": "Add New",
     "downloadGZDoom": "Download GZDoom",
+    "downloadWithLabel": "Download {{name}}",
 
     "onboarding": {
       "noSourcePorts": {

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -141,6 +141,26 @@
     }
   },
 
+  "knownSourcePorts": {
+    "info": {
+      "gzdoom": {
+        "description": "GZDoom is a feature centric port for all Doom engine games, based on ZDoom, adding an OpenGL renderer and powerful scripting capabilities."
+      },
+      "eternity": {
+        "description": "The Eternity Engine is Team Eternity's advanced Doom source port. It is meant as a versatile feature port which keeps gameplay compatibility with its roots while advancing with powerful features such as new ways to design levels and modding capabilities."
+      },
+      "chocolate-doom": {
+        "description": "Chocolate Doom is a Doom source port that accurately reproduces the experience of Doom as it was played in the 1990s."
+      },
+      "dsda": {
+        "description": "This is a successor of prboom+ with extra tooling for demo recording and playback, with a focus on speedrunning and quality of life."
+      },
+      "woof": {
+        "description": "Woof! is a continuation of the Boom/MBF bloodline of Doom source ports."
+      }
+    }
+  },
+
   "updateNotifier": {
     "actions": {
       "relaunch": "Restart",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import I18nLoader from './i18n/I18nLoader'
 import { ConfirmDialog, ConfirmDialogProvider } from './lib/ConfirmDialog'
 import NotistackMuiAlert from './mui/NotistackMuiAlert'
 import createRootStore from './redux/createRootStore'
+import { SourcePortsProvider } from './sourcePorts/sourcePortsContext'
 
 const App = lazy(() => import('./app/App'))
 
@@ -56,10 +57,12 @@ createRoot(rootElement).render(
                 }
               >
                 <I18nLoader>
-                  <ConfirmDialogProvider>
-                    <App />
-                    <ConfirmDialog />
-                  </ConfirmDialogProvider>
+                  <SourcePortsProvider>
+                    <ConfirmDialogProvider>
+                      <App />
+                      <ConfirmDialog />
+                    </ConfirmDialogProvider>
+                  </SourcePortsProvider>
                 </I18nLoader>
               </Suspense>
             </CssBaseline>

--- a/src/lib/ConfirmDialog.tsx
+++ b/src/lib/ConfirmDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mui/material'
 import {
   createContext,
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -42,29 +43,29 @@ const confirmDialogContext = createContext<{
   ui: {},
 })
 
-export const ConfirmDialogProvider: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const [ui, setUi] = useState<ConfirmDialogUiOptions>({})
-  const currentResolve = useRef<
-    (resolveFn: boolean | PromiseLike<boolean>) => void
-  >(() => {})
+export const ConfirmDialogProvider: React.FC<React.PropsWithChildren> = memo(
+  ({ children }) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const [ui, setUi] = useState<ConfirmDialogUiOptions>({})
+    const currentResolve = useRef<
+      (resolveFn: boolean | PromiseLike<boolean>) => void
+    >(() => {})
 
-  return (
-    <confirmDialogContext.Provider
-      value={{
-        currentResolve,
-        setUi,
-        setIsOpen,
-        isOpen,
-        ui,
-      }}
-    >
-      {children}
-    </confirmDialogContext.Provider>
-  )
-}
+    return (
+      <confirmDialogContext.Provider
+        value={{
+          currentResolve,
+          setUi,
+          setIsOpen,
+          isOpen,
+          ui,
+        }}
+      >
+        {children}
+      </confirmDialogContext.Provider>
+    )
+  },
+)
 
 export function useConfirmDialog() {
   const context = useContext(confirmDialogContext)
@@ -94,7 +95,7 @@ export function useConfirmDialog() {
   }
 }
 
-export const ConfirmDialog: React.FC = () => {
+export const ConfirmDialog: React.FC = memo(() => {
   const context = useContext(confirmDialogContext)
   const { t } = useI18nContext()
 
@@ -142,4 +143,4 @@ export const ConfirmDialog: React.FC = () => {
       </DialogActions>
     </Dialog>
   )
-}
+})

--- a/src/sourcePorts/KnownSourcePortsDialog.tsx
+++ b/src/sourcePorts/KnownSourcePortsDialog.tsx
@@ -1,0 +1,120 @@
+import {
+  Cancel,
+  Check,
+  Download,
+  ExpandMore,
+  OpenInNew,
+} from '@mui/icons-material'
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  Collapse,
+  Dialog,
+  DialogContent,
+  Grid,
+  Stack,
+} from '@mui/material'
+import { useState } from 'react'
+
+import { useRootDispatch, useRootSelector } from '#src/redux/helpers'
+
+import actions from './actions'
+import type { KnownSourcePortListItem } from './types'
+import useAllSourcePorts from './useAllSourcePorts'
+
+const KnownSourcePortsDialog: React.FC = () => {
+  const { knownSourcePorts } = useAllSourcePorts()
+  const isOpen = useRootSelector(
+    (state) => state.sourcePorts.isKnownSourcePortsDialogOpen,
+  )
+  const dispatch = useRootDispatch()
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={() => {
+        dispatch(actions.toggleKnownSourcePortsDialog())
+      }}
+    >
+      <DialogContent>
+        <Grid container spacing={2}>
+          {knownSourcePorts.map((x) => {
+            return (
+              <Grid key={x.id} item xs={12}>
+                <KnownSourcePortCard sourcePort={x} />
+              </Grid>
+            )
+          })}
+        </Grid>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const CHECK_MARK = <Check color="success" fontSize="small" />
+const WARNING_ICON = <Cancel color="warning" fontSize="small" />
+
+const KnownSourcePortCard: React.FC<{ sourcePort: KnownSourcePortListItem }> = (
+  props,
+) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <Card>
+      <CardHeader
+        title={props.sourcePort.name}
+        subheader={props.sourcePort.description}
+      />
+      <CardContent>
+        <Stack spacing={1} direction="row" alignItems="center">
+          {props.sourcePort.supports_custom_config ? CHECK_MARK : WARNING_ICON}
+
+          <span>Supports custom config</span>
+        </Stack>
+
+        <Stack spacing={1} direction="row" alignItems="center">
+          {props.sourcePort.supports_save_dir ? CHECK_MARK : WARNING_ICON}
+
+          <span>Supports save directory</span>
+        </Stack>
+
+        <Button
+          variant="text"
+          fullWidth
+          startIcon={<ExpandMore />}
+          onClick={() => {
+            setIsExpanded(!isExpanded)
+          }}
+        >
+          Example Command
+        </Button>
+        <Collapse in={isExpanded}>
+          <code>{props.sourcePort.example_command.join(' ')}</code>
+        </Collapse>
+      </CardContent>
+
+      <CardActions>
+        <Button
+          href={props.sourcePort.home_page_url}
+          target="_blank"
+          startIcon={<OpenInNew />}
+        >
+          Home Page
+        </Button>
+
+        <Button
+          href={props.sourcePort.download_page_url}
+          target="_blank"
+          startIcon={<Download />}
+        >
+          Download
+        </Button>
+      </CardActions>
+    </Card>
+  )
+}
+
+export default KnownSourcePortsDialog

--- a/src/sourcePorts/KnownSourcePortsDialog.tsx
+++ b/src/sourcePorts/KnownSourcePortsDialog.tsx
@@ -5,6 +5,7 @@ import {
   ExpandMore,
   OpenInNew,
 } from '@mui/icons-material'
+import type { AccordionProps } from '@mui/material'
 import {
   Accordion,
   AccordionActions,
@@ -32,8 +33,8 @@ const KnownSourcePortsDialog: React.FC = () => {
   const isOpen = useRootSelector(
     (state) => state.sourcePorts.isKnownSourcePortsDialogOpen,
   )
-  const selectedId = useRootSelector(
-    (state) => state.sourcePorts.knownSourcePortId,
+  const selectedIds = useRootSelector(
+    (state) => state.sourcePorts.selectedKnownSourcePortIds,
   )
   const dispatch = useRootDispatch()
 
@@ -60,7 +61,15 @@ const KnownSourcePortsDialog: React.FC = () => {
             <KnownSourcePortCard
               key={x.id}
               sourcePort={x}
-              defaultExpanded={x.id === selectedId}
+              expanded={selectedIds.includes(x.id)}
+              onChange={(event) => {
+                dispatch(
+                  actions.setSelectedKnownSourcePort({
+                    ids: [x.id],
+                    mode: 'toggle',
+                  }),
+                )
+              }}
             />
           )
         })}
@@ -72,15 +81,17 @@ const KnownSourcePortsDialog: React.FC = () => {
 const CHECK_MARK = <Check color="success" fontSize="small" />
 const WARNING_ICON = <Cancel color="warning" fontSize="small" />
 
-const KnownSourcePortCard: React.FC<{
+interface KnownSourcePortCardProps extends Omit<AccordionProps, 'children'> {
   sourcePort: KnownSourcePortListItem
-  defaultExpanded?: boolean
-}> = (props) => {
+}
+
+const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
+  const { sourcePort, ...accordionProps } = props
   const [isExampleCommandExpanded, setIsExampleCommandExpanded] =
     useState(false)
 
   return (
-    <Accordion defaultExpanded={props.defaultExpanded}>
+    <Accordion {...accordionProps}>
       <AccordionSummary expandIcon={<ExpandMore />}>
         {props.sourcePort.name}
       </AccordionSummary>

--- a/src/sourcePorts/KnownSourcePortsDialog.tsx
+++ b/src/sourcePorts/KnownSourcePortsDialog.tsx
@@ -6,19 +6,21 @@ import {
   OpenInNew,
 } from '@mui/icons-material'
 import {
+  Accordion,
+  AccordionActions,
+  AccordionDetails,
+  AccordionSummary,
   Button,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
   Collapse,
-  Dialog,
   DialogContent,
-  Grid,
+  DialogContentText,
   Stack,
 } from '@mui/material'
 import { useState } from 'react'
 
+import DelayedOnCloseDialog, {
+  DelayedOnCloseDialogTitleWithCloseIcon,
+} from '#src/mui/DelayedOnCloseDialog'
 import { useRootDispatch, useRootSelector } from '#src/redux/helpers'
 
 import actions from './actions'
@@ -30,45 +32,60 @@ const KnownSourcePortsDialog: React.FC = () => {
   const isOpen = useRootSelector(
     (state) => state.sourcePorts.isKnownSourcePortsDialogOpen,
   )
+  const selectedId = useRootSelector(
+    (state) => state.sourcePorts.knownSourcePortId,
+  )
   const dispatch = useRootDispatch()
 
   return (
-    <Dialog
+    <DelayedOnCloseDialog
       open={isOpen}
       onClose={() => {
         dispatch(actions.toggleKnownSourcePortsDialog())
       }}
     >
+      <DelayedOnCloseDialogTitleWithCloseIcon>
+        <span>Known Source Ports</span>
+
+        <DialogContentText>
+          WADPunk supports a number of Source Ports. Even if your favorite isn't
+          listed, it might still work: check the Example Command, and if it
+          looks similar to what you use, give it a try!
+        </DialogContentText>
+      </DelayedOnCloseDialogTitleWithCloseIcon>
+
       <DialogContent>
-        <Grid container spacing={2}>
-          {knownSourcePorts.map((x) => {
-            return (
-              <Grid key={x.id} item xs={12}>
-                <KnownSourcePortCard sourcePort={x} />
-              </Grid>
-            )
-          })}
-        </Grid>
+        {knownSourcePorts.map((x) => {
+          return (
+            <KnownSourcePortCard
+              key={x.id}
+              sourcePort={x}
+              defaultExpanded={x.id === selectedId}
+            />
+          )
+        })}
       </DialogContent>
-    </Dialog>
+    </DelayedOnCloseDialog>
   )
 }
 
 const CHECK_MARK = <Check color="success" fontSize="small" />
 const WARNING_ICON = <Cancel color="warning" fontSize="small" />
 
-const KnownSourcePortCard: React.FC<{ sourcePort: KnownSourcePortListItem }> = (
-  props,
-) => {
-  const [isExpanded, setIsExpanded] = useState(false)
+const KnownSourcePortCard: React.FC<{
+  sourcePort: KnownSourcePortListItem
+  defaultExpanded?: boolean
+}> = (props) => {
+  const [isExampleCommandExpanded, setIsExampleCommandExpanded] =
+    useState(false)
 
   return (
-    <Card>
-      <CardHeader
-        title={props.sourcePort.name}
-        subheader={props.sourcePort.description}
-      />
-      <CardContent>
+    <Accordion defaultExpanded={props.defaultExpanded}>
+      <AccordionSummary expandIcon={<ExpandMore />}>
+        {props.sourcePort.name}
+      </AccordionSummary>
+
+      <AccordionDetails>
         <Stack spacing={1} direction="row" alignItems="center">
           {props.sourcePort.supports_custom_config ? CHECK_MARK : WARNING_ICON}
 
@@ -86,17 +103,17 @@ const KnownSourcePortCard: React.FC<{ sourcePort: KnownSourcePortListItem }> = (
           fullWidth
           startIcon={<ExpandMore />}
           onClick={() => {
-            setIsExpanded(!isExpanded)
+            setIsExampleCommandExpanded(!isExampleCommandExpanded)
           }}
         >
           Example Command
         </Button>
-        <Collapse in={isExpanded}>
+        <Collapse in={isExampleCommandExpanded}>
           <code>{props.sourcePort.example_command.join(' ')}</code>
         </Collapse>
-      </CardContent>
+      </AccordionDetails>
 
-      <CardActions>
+      <AccordionActions>
         <Button
           href={props.sourcePort.home_page_url}
           target="_blank"
@@ -112,8 +129,8 @@ const KnownSourcePortCard: React.FC<{ sourcePort: KnownSourcePortListItem }> = (
         >
           Download
         </Button>
-      </CardActions>
-    </Card>
+      </AccordionActions>
+    </Accordion>
   )
 }
 

--- a/src/sourcePorts/KnownSourcePortsDialog.tsx
+++ b/src/sourcePorts/KnownSourcePortsDialog.tsx
@@ -27,11 +27,11 @@ import DelayedOnCloseDialog, {
 import { useRootDispatch, useRootSelector } from '#src/redux/helpers'
 
 import actions from './actions'
+import { useSourcePortsContext } from './sourcePortsContext'
 import type { KnownSourcePortListItem } from './types'
-import useAllSourcePorts from './useAllSourcePorts'
 
 const KnownSourcePortsDialog: React.FC = () => {
-  const { knownSourcePorts } = useAllSourcePorts()
+  const { knownSourcePorts } = useSourcePortsContext()
   const isOpen = useRootSelector(
     (state) => state.sourcePorts.isKnownSourcePortsDialogOpen,
   )
@@ -130,6 +130,7 @@ const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
           variant="text"
           fullWidth
           startIcon={<ExpandMore />}
+          size="small"
           onClick={() => {
             setIsExampleCommandExpanded(!isExampleCommandExpanded)
           }}

--- a/src/sourcePorts/KnownSourcePortsDialog.tsx
+++ b/src/sourcePorts/KnownSourcePortsDialog.tsx
@@ -16,9 +16,11 @@ import {
   DialogContent,
   DialogContentText,
   Stack,
+  Typography,
 } from '@mui/material'
 import { useState } from 'react'
 
+import { useI18nContext } from '#src/i18n/lib/i18nContext'
 import DelayedOnCloseDialog, {
   DelayedOnCloseDialogTitleWithCloseIcon,
 } from '#src/mui/DelayedOnCloseDialog'
@@ -86,9 +88,14 @@ interface KnownSourcePortCardProps extends Omit<AccordionProps, 'children'> {
 }
 
 const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
+  const { t } = useI18nContext()
   const { sourcePort, ...accordionProps } = props
   const [isExampleCommandExpanded, setIsExampleCommandExpanded] =
     useState(false)
+  const description = t(
+    `knownSourcePorts.info.${props.sourcePort.id}.description`,
+    { defaultValue: '' },
+  )
 
   return (
     <Accordion {...accordionProps}>
@@ -109,6 +116,16 @@ const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
           <span>Supports save directory</span>
         </Stack>
 
+        {description ? (
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ marginY: 2 }}
+          >
+            {description}
+          </Typography>
+        ) : undefined}
+
         <Button
           variant="text"
           fullWidth
@@ -120,7 +137,9 @@ const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
           Example Command
         </Button>
         <Collapse in={isExampleCommandExpanded}>
-          <code>{props.sourcePort.example_command.join(' ')}</code>
+          <Typography variant="body2">
+            <code>{props.sourcePort.example_command.join(' ')}</code>
+          </Typography>
         </Collapse>
       </AccordionDetails>
 
@@ -129,6 +148,7 @@ const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
           href={props.sourcePort.home_page_url}
           target="_blank"
           startIcon={<OpenInNew />}
+          size="small"
         >
           Home Page
         </Button>
@@ -137,6 +157,7 @@ const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
           href={props.sourcePort.download_page_url}
           target="_blank"
           startIcon={<Download />}
+          size="small"
         >
           Download
         </Button>

--- a/src/sourcePorts/SourcePortForm.tsx
+++ b/src/sourcePorts/SourcePortForm.tsx
@@ -1,12 +1,21 @@
 import { Edit, Terminal } from '@mui/icons-material'
-import { Box, Button, InputAdornment, MenuItem, Stack } from '@mui/material'
+import {
+  Box,
+  Button,
+  InputAdornment,
+  Link,
+  MenuItem,
+  Stack,
+} from '@mui/material'
 import { forwardRef, useImperativeHandle } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { useI18nContext } from '#src/i18n/lib/i18nContext'
 import ReactHookFormTextField from '#src/react-hook-form/ReactHookFormTextField'
+import { useRootDispatch } from '#src/redux/helpers'
 
+import actions from './actions'
 import useAllSourcePorts from './useAllSourcePorts'
 
 export interface AddSourcePortFormValues {
@@ -32,6 +41,7 @@ const SourcePortForm = forwardRef<
   const { t } = useI18nContext()
   useImperativeHandle(ref, () => formApi, [formApi])
   const { knownSourcePorts } = useAllSourcePorts()
+  const dispatch = useRootDispatch()
 
   return (
     <FormProvider {...formApi}>
@@ -54,6 +64,17 @@ const SourcePortForm = forwardRef<
           label="Type"
           select
           sx={{ flex: '0 0 250px' }}
+          helperText={
+            <>
+              <Link
+                onClick={() => {
+                  dispatch(actions.toggleKnownSourcePortsDialog())
+                }}
+              >
+                More Info
+              </Link>
+            </>
+          }
         >
           {knownSourcePorts.map((sourcePort) => {
             return (

--- a/src/sourcePorts/SourcePortForm.tsx
+++ b/src/sourcePorts/SourcePortForm.tsx
@@ -16,7 +16,7 @@ import ReactHookFormTextField from '#src/react-hook-form/ReactHookFormTextField'
 import { useRootDispatch } from '#src/redux/helpers'
 
 import actions from './actions'
-import useAllSourcePorts from './useAllSourcePorts'
+import { useSourcePortsContext } from './sourcePortsContext'
 
 export interface AddSourcePortFormValues {
   id: string
@@ -40,7 +40,7 @@ const SourcePortForm = forwardRef<
   })
   const { t } = useI18nContext()
   useImperativeHandle(ref, () => formApi, [formApi])
-  const { knownSourcePorts } = useAllSourcePorts()
+  const { knownSourcePorts } = useSourcePortsContext()
   const dispatch = useRootDispatch()
   const knownSourcePortId = formApi.watch('known_source_port_id')
 

--- a/src/sourcePorts/SourcePortForm.tsx
+++ b/src/sourcePorts/SourcePortForm.tsx
@@ -42,6 +42,7 @@ const SourcePortForm = forwardRef<
   useImperativeHandle(ref, () => formApi, [formApi])
   const { knownSourcePorts } = useAllSourcePorts()
   const dispatch = useRootDispatch()
+  const knownSourcePortId = formApi.watch('known_source_port_id')
 
   return (
     <FormProvider {...formApi}>
@@ -63,11 +64,17 @@ const SourcePortForm = forwardRef<
           name="known_source_port_id"
           label="Type"
           select
-          sx={{ flex: '0 0 250px' }}
+          sx={{ flex: '0 0 200px' }}
           helperText={
             <>
               <Link
                 onClick={() => {
+                  dispatch(
+                    actions.setSelectedKnownSourcePort({
+                      ids: [knownSourcePortId],
+                      mode: 'exclusive',
+                    }),
+                  )
                   dispatch(actions.toggleKnownSourcePortsDialog())
                 }}
               >

--- a/src/sourcePorts/SourcePortForm.tsx
+++ b/src/sourcePorts/SourcePortForm.tsx
@@ -1,5 +1,5 @@
 import { Edit, Terminal } from '@mui/icons-material'
-import { Box, Button, InputAdornment, Stack } from '@mui/material'
+import { Box, Button, InputAdornment, MenuItem, Stack } from '@mui/material'
 import { forwardRef, useImperativeHandle } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -7,9 +7,12 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { useI18nContext } from '#src/i18n/lib/i18nContext'
 import ReactHookFormTextField from '#src/react-hook-form/ReactHookFormTextField'
 
+import useAllSourcePorts from './useAllSourcePorts'
+
 export interface AddSourcePortFormValues {
   id: string
   command: string
+  known_source_port_id: string
 }
 
 const SourcePortForm = forwardRef<
@@ -28,21 +31,40 @@ const SourcePortForm = forwardRef<
   })
   const { t } = useI18nContext()
   useImperativeHandle(ref, () => formApi, [formApi])
+  const { knownSourcePorts } = useAllSourcePorts()
 
   return (
     <FormProvider {...formApi}>
-      <ReactHookFormTextField
-        name="id"
-        label={t('sourcePorts.fields.id.label')}
-        disabled={props.sourcePort.id !== ''}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <Edit />
-            </InputAdornment>
-          ),
-        }}
-      />
+      <Stack spacing={2} direction="row">
+        <ReactHookFormTextField
+          name="id"
+          label={t('sourcePorts.fields.id.label')}
+          disabled={props.sourcePort.id !== ''}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Edit />
+              </InputAdornment>
+            ),
+          }}
+        />
+
+        <ReactHookFormTextField
+          name="known_source_port_id"
+          label="Type"
+          select
+          sx={{ flex: '0 0 250px' }}
+        >
+          {knownSourcePorts.map((sourcePort) => {
+            return (
+              <MenuItem key={sourcePort.id} value={sourcePort.id}>
+                {sourcePort.name}
+              </MenuItem>
+            )
+          })}
+        </ReactHookFormTextField>
+      </Stack>
+
       <ReactHookFormTextField
         name="command"
         label={t('sourcePorts.fields.command.label')}

--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -37,7 +37,7 @@ import SourcePortForm from './SourcePortForm'
 import useAllSourcePorts from './useAllSourcePorts'
 
 const SourcePortsDialog: React.FC = () => {
-  const { sourcePorts } = useAllSourcePorts()
+  const { sourcePorts, knownSourcePorts } = useAllSourcePorts()
   const isOpen = useRootSelector((state) => state.sourcePorts.isDialogOpen)
   const dispatch = useRootDispatch()
   const [createSourcePort] = useMutation(CreateSourcePortDocument)
@@ -161,6 +161,7 @@ const SourcePortsDialog: React.FC = () => {
                       }
                     : {
                         id: '',
+                        known_source_port_id: 'gzdoom',
                         command: '',
                       }
                 }
@@ -170,6 +171,7 @@ const SourcePortsDialog: React.FC = () => {
                       variables: {
                         source_port: {
                           id: values.id,
+                          known_source_port_id: values.known_source_port_id,
                           // TODO This is a hack because I don't want to deal with the
                           // array-ness of the command in the UI yet.
                           command: values.command ? [values.command] : [],
@@ -187,6 +189,7 @@ const SourcePortsDialog: React.FC = () => {
                       variables: {
                         source_port: {
                           id: selectedId,
+                          known_source_port_id: values.known_source_port_id,
                           command: values.command ? [values.command] : [],
                         },
                       },

--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -37,7 +37,7 @@ import SourcePortForm from './SourcePortForm'
 import useAllSourcePorts from './useAllSourcePorts'
 
 const SourcePortsDialog: React.FC = () => {
-  const { sourcePorts } = useAllSourcePorts()
+  const { sourcePorts, knownSourcePorts } = useAllSourcePorts()
   const isOpen = useRootSelector((state) => state.sourcePorts.isDialogOpen)
   const dispatch = useRootDispatch()
   const [createSourcePort] = useMutation(CreateSourcePortDocument)
@@ -52,6 +52,12 @@ const SourcePortsDialog: React.FC = () => {
 
   const { t } = useI18nContext()
   const isAddingNew = selectedId === '-1'
+
+  const gzdoom = knownSourcePorts.find((x) => x.id === 'gzdoom')
+
+  if (!gzdoom) {
+    throw new Error('gzdoom known source port not found')
+  }
 
   const tauriFileDrop = useTauriFileDrop(async (event) => {
     if (!isOpen) {
@@ -134,10 +140,10 @@ const SourcePortsDialog: React.FC = () => {
 
                 <Button
                   startIcon={<Download />}
-                  href="https://zdoom.org/downloads"
+                  href={gzdoom.download_page_url}
                   target="_blank"
                 >
-                  {t('sourcePorts.downloadGZDoom')}
+                  {t('sourcePorts.downloadWithLabel', { name: gzdoom.name })}
                 </Button>
               </Box>
             </Box>

--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -85,7 +85,7 @@ const SourcePortsDialog: React.FC = () => {
             spacing={2}
             divider={<Divider orientation="vertical" flexItem />}
           >
-            <Box sx={{ width: '300px' }}>
+            <Box sx={{ flex: '0 0 300px' }}>
               <List dense disablePadding>
                 <ListItem divider disablePadding>
                   <ListItemButton
@@ -142,7 +142,7 @@ const SourcePortsDialog: React.FC = () => {
               </Box>
             </Box>
 
-            <Box style={{ flexGrow: '1' }}>
+            <Box flexGrow="1">
               <SourcePortForm
                 // key is needed here for react-hook-form. Without it, even though
                 // new objects are passed to `defaultValues`, it never reflects

--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -37,7 +37,7 @@ import SourcePortForm from './SourcePortForm'
 import useAllSourcePorts from './useAllSourcePorts'
 
 const SourcePortsDialog: React.FC = () => {
-  const { sourcePorts, knownSourcePorts } = useAllSourcePorts()
+  const { sourcePorts } = useAllSourcePorts()
   const isOpen = useRootSelector((state) => state.sourcePorts.isDialogOpen)
   const dispatch = useRootDispatch()
   const [createSourcePort] = useMutation(CreateSourcePortDocument)

--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -34,10 +34,10 @@ import useTauriFileDrop from '#src/tauri/useTauriFileDrop'
 import actions from './actions'
 import type { AddSourcePortFormValues } from './SourcePortForm'
 import SourcePortForm from './SourcePortForm'
-import useAllSourcePorts from './useAllSourcePorts'
+import { useSourcePortsContext } from './sourcePortsContext'
 
 const SourcePortsDialog: React.FC = () => {
-  const { sourcePorts, knownSourcePorts } = useAllSourcePorts()
+  const { sourcePorts, knownSourcePorts } = useSourcePortsContext()
   const isOpen = useRootSelector((state) => state.sourcePorts.isDialogOpen)
   const dispatch = useRootDispatch()
   const [createSourcePort] = useMutation(CreateSourcePortDocument)
@@ -132,7 +132,7 @@ const SourcePortsDialog: React.FC = () => {
                 <Typography
                   variant="body2"
                   color="text.secondary"
-                  gutterBottom
+                  paragraph
                   sx={{ marginTop: 1 }}
                 >
                   Don't know where to get started?

--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -140,8 +140,15 @@ const SourcePortsDialog: React.FC = () => {
 
                 <Button
                   startIcon={<Download />}
-                  href={gzdoom.download_page_url}
-                  target="_blank"
+                  onClick={() => {
+                    dispatch(
+                      actions.setSelectedKnownSourcePort({
+                        ids: ['gzdoom'],
+                        mode: 'exclusive',
+                      }),
+                    )
+                    dispatch(actions.toggleKnownSourcePortsDialog())
+                  }}
                 >
                   {t('sourcePorts.downloadWithLabel', { name: gzdoom.name })}
                 </Button>

--- a/src/sourcePorts/actions.ts
+++ b/src/sourcePorts/actions.ts
@@ -5,4 +5,5 @@ export default createActions('sourcePorts', {
   setSelectedId: (id: string) => ({ id }),
 
   toggleKnownSourcePortsDialog: () => {},
+  setSelectedKnownSourcePort: (id: string) => ({ id }),
 })

--- a/src/sourcePorts/actions.ts
+++ b/src/sourcePorts/actions.ts
@@ -5,5 +5,8 @@ export default createActions('sourcePorts', {
   setSelectedId: (id: string) => ({ id }),
 
   toggleKnownSourcePortsDialog: () => {},
-  setSelectedKnownSourcePort: (id: string) => ({ id }),
+  setSelectedKnownSourcePort: (args: {
+    ids: string[]
+    mode: 'exclusive' | 'toggle'
+  }) => args,
 })

--- a/src/sourcePorts/actions.ts
+++ b/src/sourcePorts/actions.ts
@@ -3,4 +3,6 @@ import { createActions } from 'redux-easy-mode'
 export default createActions('sourcePorts', {
   toggleDialog: () => {},
   setSelectedId: (id: string) => ({ id }),
+
+  toggleKnownSourcePortsDialog: () => {},
 })

--- a/src/sourcePorts/operations.graphql
+++ b/src/sourcePorts/operations.graphql
@@ -10,6 +10,8 @@ query getAllSourcePorts {
     id
     name
     description
+    home_page_url
+    download_page_url
     supports_custom_config
     supports_save_dir
     example_command

--- a/src/sourcePorts/operations.graphql
+++ b/src/sourcePorts/operations.graphql
@@ -9,7 +9,6 @@ query getAllSourcePorts {
   getKnownSourcePorts {
     id
     name
-    description
     home_page_url
     download_page_url
     supports_custom_config

--- a/src/sourcePorts/operations.graphql
+++ b/src/sourcePorts/operations.graphql
@@ -2,7 +2,16 @@ query getAllSourcePorts {
   getSourcePorts {
     id
     command
+    known_source_port_id
     is_default
+  }
+
+  getKnownSourcePorts {
+    id
+    name
+    description
+    supports_custom_config
+    supports_save_dir
   }
 }
 

--- a/src/sourcePorts/operations.graphql
+++ b/src/sourcePorts/operations.graphql
@@ -12,6 +12,7 @@ query getAllSourcePorts {
     description
     supports_custom_config
     supports_save_dir
+    example_command
   }
 }
 

--- a/src/sourcePorts/reducer.ts
+++ b/src/sourcePorts/reducer.ts
@@ -6,14 +6,14 @@ export interface State {
   isDialogOpen: boolean
   selectedId: string
   isKnownSourcePortsDialogOpen: boolean
-  knownSourcePortId: string
+  selectedKnownSourcePortIds: string[]
 }
 
 export const initialState: State = {
   isDialogOpen: false,
   selectedId: '-1',
   isKnownSourcePortsDialogOpen: false,
-  knownSourcePortId: '-1',
+  selectedKnownSourcePortIds: [],
 }
 
 export const reducer = createReducer(initialState, (builder) => {
@@ -30,8 +30,29 @@ export const reducer = createReducer(initialState, (builder) => {
       ...state,
       isKnownSourcePortsDialogOpen: !state.isKnownSourcePortsDialogOpen,
     }))
-    .addHandler(actions.setSelectedKnownSourcePort, (state, action) => ({
-      ...state,
-      knownSourcePortId: action.payload.id,
-    }))
+    .addHandler(actions.setSelectedKnownSourcePort, (state, action) => {
+      const { ids, mode } = action.payload
+      let selectedKnownSourcePortIds: string[] = []
+
+      if (mode === 'exclusive') {
+        selectedKnownSourcePortIds = [...ids]
+      } else if (mode === 'toggle') {
+        for (const id of ids) {
+          if (state.selectedKnownSourcePortIds.includes(id)) {
+            selectedKnownSourcePortIds =
+              state.selectedKnownSourcePortIds.filter((x) => x !== id)
+          } else {
+            selectedKnownSourcePortIds = [
+              ...state.selectedKnownSourcePortIds,
+              id,
+            ]
+          }
+        }
+      }
+
+      return {
+        ...state,
+        selectedKnownSourcePortIds,
+      }
+    })
 })

--- a/src/sourcePorts/reducer.ts
+++ b/src/sourcePorts/reducer.ts
@@ -5,11 +5,13 @@ import actions from './actions'
 export interface State {
   isDialogOpen: boolean
   selectedId: string
+  isKnownSourcePortsDialogOpen: boolean
 }
 
 export const initialState: State = {
   isDialogOpen: false,
   selectedId: '-1',
+  isKnownSourcePortsDialogOpen: false,
 }
 
 export const reducer = createReducer(initialState, (builder) => {
@@ -21,5 +23,9 @@ export const reducer = createReducer(initialState, (builder) => {
     .addHandler(actions.setSelectedId, (state, action) => ({
       ...state,
       selectedId: action.payload.id,
+    }))
+    .addHandler(actions.toggleKnownSourcePortsDialog, (state, action) => ({
+      ...state,
+      isKnownSourcePortsDialogOpen: !state.isKnownSourcePortsDialogOpen,
     }))
 })

--- a/src/sourcePorts/reducer.ts
+++ b/src/sourcePorts/reducer.ts
@@ -6,12 +6,14 @@ export interface State {
   isDialogOpen: boolean
   selectedId: string
   isKnownSourcePortsDialogOpen: boolean
+  knownSourcePortId: string
 }
 
 export const initialState: State = {
   isDialogOpen: false,
   selectedId: '-1',
   isKnownSourcePortsDialogOpen: false,
+  knownSourcePortId: '-1',
 }
 
 export const reducer = createReducer(initialState, (builder) => {
@@ -27,5 +29,9 @@ export const reducer = createReducer(initialState, (builder) => {
     .addHandler(actions.toggleKnownSourcePortsDialog, (state, action) => ({
       ...state,
       isKnownSourcePortsDialogOpen: !state.isKnownSourcePortsDialogOpen,
+    }))
+    .addHandler(actions.setSelectedKnownSourcePort, (state, action) => ({
+      ...state,
+      knownSourcePortId: action.payload.id,
     }))
 })

--- a/src/sourcePorts/sourcePortsContext.tsx
+++ b/src/sourcePorts/sourcePortsContext.tsx
@@ -1,0 +1,88 @@
+import { useSuspenseQuery } from '@apollo/client'
+import type { RefetchFunction } from '@apollo/client/react/hooks/useSuspenseQuery'
+import { createContext, memo, useContext, useMemo } from 'react'
+
+import type {
+  GetAllSourcePortsQuery,
+  GetAllSourcePortsQueryVariables,
+} from '#src/graphql/operations'
+import { GetAllSourcePortsDocument } from '#src/graphql/operations'
+import type { SourcePort } from '#src/graphql/types'
+
+import type { KnownSourcePortListItem, SourcePortListSourcePort } from './types'
+
+interface SourcePortsContextType {
+  sourcePorts: SourcePortListSourcePort[]
+  knownSourcePorts: KnownSourcePortListItem[]
+  defaultSourcePort?: SourcePortListSourcePort
+  findSourcePortById: (
+    id?: SourcePort['id'] | null,
+  ) => SourcePortListSourcePort | undefined
+  refetch: RefetchFunction<
+    GetAllSourcePortsQuery,
+    GetAllSourcePortsQueryVariables
+  >
+}
+
+const sourcePortsContext = createContext<SourcePortsContextType | undefined>(
+  undefined,
+)
+
+export const SourcePortsProvider: React.FC<React.PropsWithChildren> = memo(
+  (props) => {
+    const { data, refetch } = useSuspenseQuery(GetAllSourcePortsDocument)
+
+    const contextValue = useMemo(() => {
+      const sortedSourcePorts = [...data.getSourcePorts].sort((a, b) => {
+        return a.id.localeCompare(b.id)
+      })
+
+      const sortedKnownSourcePorts = [...data.getKnownSourcePorts].sort(
+        (a, b) => {
+          return a.name.localeCompare(b.name)
+        },
+      )
+
+      const defaultSourcePort =
+        data.getSourcePorts.find((x) => x.is_default) || data.getSourcePorts[0]
+
+      const findSourcePortById = (id?: SourcePort['id'] | null) => {
+        if (!id || id === '-1') {
+          return defaultSourcePort
+        }
+
+        return data.getSourcePorts.find((x) => x.id === id)
+      }
+
+      const contextValue: SourcePortsContextType = {
+        sourcePorts: sortedSourcePorts,
+        knownSourcePorts: sortedKnownSourcePorts,
+        defaultSourcePort,
+        findSourcePortById,
+        refetch,
+      }
+
+      return contextValue
+    }, [data, refetch])
+
+    return (
+      <sourcePortsContext.Provider value={contextValue}>
+        {props.children}
+      </sourcePortsContext.Provider>
+    )
+  },
+)
+
+export const SourcePortsConsumer = sourcePortsContext.Consumer
+
+export function useSourcePortsContext() {
+  const context = useContext(sourcePortsContext)
+
+  if (!context) {
+    throw new Error(
+      'useSourcePortsContext must be used within a SourcePortsProvider',
+    )
+  }
+
+  return context
+}

--- a/src/sourcePorts/types.ts
+++ b/src/sourcePorts/types.ts
@@ -1,0 +1,9 @@
+import type { GetAllSourcePortsQuery } from '#src/graphql/operations'
+
+export type SourcePortListSourcePort = ArrayItemType<
+  GetAllSourcePortsQuery['getSourcePorts']
+>
+
+export type KnownSourcePortListItem = ArrayItemType<
+  GetAllSourcePortsQuery['getKnownSourcePorts']
+>

--- a/src/sourcePorts/useAllSourcePorts.ts
+++ b/src/sourcePorts/useAllSourcePorts.ts
@@ -29,6 +29,7 @@ function useAllSourcePorts() {
 
   return {
     sourcePorts: sortedSourcePorts,
+    knownSourcePorts: data.getKnownSourcePorts,
     defaultSourcePort,
     findSourcePortById,
     refetch,

--- a/src/sourcePorts/useAllSourcePorts.ts
+++ b/src/sourcePorts/useAllSourcePorts.ts
@@ -27,9 +27,19 @@ function useAllSourcePorts() {
     [data.getSourcePorts, defaultSourcePort],
   )
 
+  const sortedKnownSourcePorts = useMemo(() => {
+    const sortedKnownSourcePorts = [...data.getKnownSourcePorts]
+
+    sortedKnownSourcePorts.sort((a, b) => {
+      return a.name.localeCompare(b.name)
+    })
+
+    return sortedKnownSourcePorts
+  }, [data.getKnownSourcePorts])
+
   return {
     sourcePorts: sortedSourcePorts,
-    knownSourcePorts: data.getKnownSourcePorts,
+    knownSourcePorts: sortedKnownSourcePorts,
     defaultSourcePort,
     findSourcePortById,
     refetch,

--- a/src/tauri/useTauriFileDrop.ts
+++ b/src/tauri/useTauriFileDrop.ts
@@ -9,9 +9,16 @@ function useTauriFileDrop(callback: (event: Event<string[]>) => void) {
   const callbackRef = useLatest(callback)
 
   useEffect(() => {
-    const stopListeningHover = listen(TauriEvent.WINDOW_FILE_DROP_HOVER, () => {
-      setIsDraggingOver(true)
-    })
+    const stopListeningHover = listen<string[]>(
+      TauriEvent.WINDOW_FILE_DROP_HOVER,
+      (event) => {
+        if (event.payload.length === 0) {
+          return
+        }
+
+        setIsDraggingOver(true)
+      },
+    )
 
     const stopListeningCancelled = listen(
       TauriEvent.WINDOW_FILE_DROP_CANCELLED,
@@ -24,6 +31,11 @@ function useTauriFileDrop(callback: (event: Event<string[]>) => void) {
       TauriEvent.WINDOW_FILE_DROP,
       (event) => {
         setIsDraggingOver(false)
+
+        if (event.payload.length === 0) {
+          return
+        }
+
         callbackRef.current(event)
       },
     )


### PR DESCRIPTION
Source Ports can now be associated with a "known source port" (great naming isn't it?). This allows WADPunk to pass the correct command line args.

It defaults to "gzdoom", possibly forever.

Closes #74 

## Preview


https://github.com/mikew/wadpunk/assets/4729/5bdce818-99e9-40d0-9feb-d7a9108a0c07

