### PR TITLE
fix: Fix external links (again 🙃)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -811,7 +811,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -870,7 +870,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1596,7 +1596,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1841,7 +1841,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2052,6 +2052,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "open"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
+dependencies = [
+ "pathdiff",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2158,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -2700,7 +2716,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2736,7 +2752,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3220,9 +3236,11 @@ dependencies = [
  "minisign-verify",
  "objc",
  "once_cell",
+ "open",
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
+ "regex",
  "reqwest",
  "rfd",
  "semver",
@@ -3281,6 +3299,7 @@ dependencies = [
  "png",
  "proc-macro2",
  "quote",
+ "regex",
  "semver",
  "serde",
  "serde_json",
@@ -3425,7 +3444,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3535,7 +3554,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4120,6 +4139,21 @@ checksum = "9ee5e275231f07c6e240d14f34e1b635bf1faa1c76c57cfd59a5cdb9848e4278"
 
 [[package]]
 name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -4174,6 +4208,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
@@ -4195,6 +4235,12 @@ name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4222,6 +4268,12 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
@@ -4243,6 +4295,12 @@ name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4270,6 +4328,12 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
@@ -4279,6 +4343,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4303,6 +4373,12 @@ name = "windows_x86_64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4342,7 +4418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "process-relaunch", "process-exit", "updater"] }
+tauri = { version = "1.4", features = [ "shell-open", "process-relaunch", "process-exit", "updater"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri-plugin-graphql = "2.0.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,9 @@
 
   "tauri": {
     "allowlist": {
+      "shell": {
+        "open": ".*"
+      },
       "process": {
         "relaunch": true,
         "exit": true

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -15,7 +15,6 @@ import AppCogMenu from './AppCogMenu'
 import { AppToolbarProvider, AppToolbarSlot } from './AppToolbarArea'
 import OnboardingAlerts from './OnboardingAlerts'
 import { InitializeAppDocument } from './operations.generated'
-import UpdateNotifier from './UpdateNotifier'
 
 function App() {
   return (
@@ -54,8 +53,6 @@ function App() {
 
         <SourcePortsDialog />
         <KnownSourcePortsDialog />
-
-        <UpdateNotifier />
       </SourcePortsProvider>
     </Initializer>
   )

--- a/src/app/OnboardingAlerts.tsx
+++ b/src/app/OnboardingAlerts.tsx
@@ -52,7 +52,6 @@ const OnboardingAlerts: React.FC = () => {
                 size="small"
                 startIcon={<Download />}
                 href="https://freedoom.github.io/download.html"
-                target="_blank"
               >
                 {t('games.onboarding.noGames.downloadFreedoom')}
               </Button>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,13 +14,13 @@ import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 
 import theme from './app/theme'
-import UpdateNotifier from './app/UpdateNotifier'
 import graphqlClient from './graphql/graphqlClient'
 import I18nLoader from './i18n/I18nLoader'
 import { ConfirmDialog, ConfirmDialogProvider } from './lib/ConfirmDialog'
 import NotistackMuiAlert from './mui/NotistackMuiAlert'
 import createRootStore from './redux/createRootStore'
 import TauriExternalLinkHandler from './tauri/TauriExternalLinkHandler'
+import TauriUpdateNotifier from './tauri/TauriUpdateNotifier'
 
 const App = lazy(() => import('./app/App'))
 
@@ -60,8 +60,11 @@ createRoot(rootElement).render(
                 <I18nLoader>
                   <ConfirmDialogProvider>
                     <App />
+
                     <ConfirmDialog />
-                    <UpdateNotifier />
+
+                    <TauriUpdateNotifier />
+
                     <TauriExternalLinkHandler />
                   </ConfirmDialogProvider>
                 </I18nLoader>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import I18nLoader from './i18n/I18nLoader'
 import { ConfirmDialog, ConfirmDialogProvider } from './lib/ConfirmDialog'
 import NotistackMuiAlert from './mui/NotistackMuiAlert'
 import createRootStore from './redux/createRootStore'
+import TauriExternalLinkHandler from './tauri/TauriExternalLinkHandler'
 
 const App = lazy(() => import('./app/App'))
 
@@ -59,6 +60,7 @@ createRoot(rootElement).render(
                   <ConfirmDialogProvider>
                     <App />
                     <ConfirmDialog />
+                    <TauriExternalLinkHandler />
                   </ConfirmDialogProvider>
                 </I18nLoader>
               </Suspense>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 
 import theme from './app/theme'
+import UpdateNotifier from './app/UpdateNotifier'
 import graphqlClient from './graphql/graphqlClient'
 import I18nLoader from './i18n/I18nLoader'
 import { ConfirmDialog, ConfirmDialogProvider } from './lib/ConfirmDialog'
@@ -60,6 +61,7 @@ createRoot(rootElement).render(
                   <ConfirmDialogProvider>
                     <App />
                     <ConfirmDialog />
+                    <UpdateNotifier />
                     <TauriExternalLinkHandler />
                   </ConfirmDialogProvider>
                 </I18nLoader>

--- a/src/lib/StarRating.tsx
+++ b/src/lib/StarRating.tsx
@@ -47,7 +47,6 @@ const StarRating: React.FC<{
           }
 
           const sharedProps: SvgIconProps = {
-            key: x,
             fontSize: 'inherit',
             onClick: handleClick,
             sx: {
@@ -61,14 +60,14 @@ const StarRating: React.FC<{
 
           return hoverIndex != null ? (
             hoverIndex >= x ? (
-              <Star {...sharedProps} />
+              <Star key={x} {...sharedProps} />
             ) : (
-              <StarBorder {...sharedProps} />
+              <StarBorder key={x} {...sharedProps} />
             )
           ) : props.value >= x ? (
-            <Star {...sharedProps} />
+            <Star key={x} {...sharedProps} />
           ) : (
-            <StarBorder {...sharedProps} />
+            <StarBorder key={x} {...sharedProps} />
           )
         })}
       </Stack>

--- a/src/sourcePorts/KnownSourcePortsDialog.tsx
+++ b/src/sourcePorts/KnownSourcePortsDialog.tsx
@@ -147,7 +147,6 @@ const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
       <AccordionActions>
         <Button
           href={props.sourcePort.home_page_url}
-          target="_blank"
           startIcon={<OpenInNew />}
           size="small"
         >
@@ -156,7 +155,6 @@ const KnownSourcePortCard: React.FC<KnownSourcePortCardProps> = (props) => {
 
         <Button
           href={props.sourcePort.download_page_url}
-          target="_blank"
           startIcon={<Download />}
           size="small"
         >

--- a/src/tauri/TauriExternalLinkHandler.tsx
+++ b/src/tauri/TauriExternalLinkHandler.tsx
@@ -3,22 +3,37 @@ import { useEffect } from 'react'
 
 const TauriExternalLinkHandler: React.FC = () => {
   useEffect(() => {
-    document.documentElement.addEventListener('click', (event) => {
+    function handleClick(event: MouseEvent) {
       const target = event.target
 
-      if (!(target instanceof HTMLElement)) {
+      if (!(target instanceof Element)) {
         return
       }
 
-      if (target.tagName === 'A') {
-        const href = target.getAttribute('href')
+      const closestLink = target.closest('a')
 
-        if (href?.startsWith('http')) {
-          event.preventDefault()
-          shell.open(href)
-        }
+      if (!closestLink) {
+        return
       }
-    })
+
+      const href = closestLink.getAttribute('href')
+
+      if (
+        href &&
+        ['http://', 'https://', 'mailto:', 'tel:'].some((v) =>
+          href.startsWith(v),
+        )
+      ) {
+        event.preventDefault()
+        shell.open(href)
+      }
+    }
+
+    document.documentElement.addEventListener('click', handleClick, true)
+
+    return () => {
+      document.documentElement.removeEventListener('click', handleClick, true)
+    }
   }, [])
 
   return null

--- a/src/tauri/TauriExternalLinkHandler.tsx
+++ b/src/tauri/TauriExternalLinkHandler.tsx
@@ -1,0 +1,27 @@
+import { shell } from '@tauri-apps/api'
+import { useEffect } from 'react'
+
+const TauriExternalLinkHandler: React.FC = () => {
+  useEffect(() => {
+    document.documentElement.addEventListener('click', (event) => {
+      const target = event.target
+
+      if (!(target instanceof HTMLElement)) {
+        return
+      }
+
+      if (target.tagName === 'A') {
+        const href = target.getAttribute('href')
+
+        if (href?.startsWith('http')) {
+          event.preventDefault()
+          shell.open(href)
+        }
+      }
+    })
+  }, [])
+
+  return null
+}
+
+export default TauriExternalLinkHandler

--- a/src/tauri/TauriUpdateNotifier.tsx
+++ b/src/tauri/TauriUpdateNotifier.tsx
@@ -91,7 +91,7 @@ const TauriUpdateNotifier: React.FC = () => {
         </Button>
       ) : undefined}
 
-      {status === 'UPDATE_AVAILABLE' ? (
+      {status === 'UPDATE_AVAILABLE' || status === 'RESTART_REQUIRED' ? (
         <Button
           size="small"
           color="inherit"

--- a/src/tauri/TauriUpdateNotifier.tsx
+++ b/src/tauri/TauriUpdateNotifier.tsx
@@ -1,6 +1,7 @@
 import { Update } from '@mui/icons-material'
 import {
   Alert,
+  Box,
   Button,
   CircularProgress,
   Dialog,
@@ -9,6 +10,7 @@ import {
   Snackbar,
   Stack,
 } from '@mui/material'
+import getTextDecoration from '@mui/material/Link/getTextDecoration'
 import { relaunch } from '@tauri-apps/api/process'
 import type { UpdateResult } from '@tauri-apps/api/updater'
 import { checkUpdate, installUpdate } from '@tauri-apps/api/updater'
@@ -125,6 +127,7 @@ const TauriUpdateNotifier: React.FC = () => {
 
       <Dialog
         open={isReleaseNotesDialogVisible}
+        fullWidth
         onClose={() => {
           setIsReleaseNotesDialogVisible(false)
         }}
@@ -136,10 +139,23 @@ const TauriUpdateNotifier: React.FC = () => {
         </DialogTitle>
 
         <DialogContent>
-          <div
-            // eslint-disable-next-line react/no-danger -- need to render markdown.
+          <Box
+            sx={(theme) => ({
+              // Adapted from https://github.com/mui/material-ui/blob/v5.x/packages/mui-material/src/Link/Link.js
+              '& a': {
+                'color': 'primary.main',
+                'textDecoration': 'underline',
+                'textDecorationColor': getTextDecoration({
+                  theme,
+                  ownerState: { color: 'primary' },
+                }),
+                '&:hover': {
+                  textDecorationColor: 'inherit',
+                },
+              },
+            })}
             dangerouslySetInnerHTML={{
-              __html: parse(updateManifest?.body ?? ''),
+              __html: parse(tauriUpdateResult?.manifest?.body ?? ''),
             }}
           />
         </DialogContent>

--- a/src/tauri/TauriUpdateNotifier.tsx
+++ b/src/tauri/TauriUpdateNotifier.tsx
@@ -18,7 +18,7 @@ import { useEffect, useState } from 'react'
 
 import { useI18nContext } from '#src/i18n/lib/i18nContext'
 
-const UpdateNotifier: React.FC = () => {
+const TauriUpdateNotifier: React.FC = () => {
   const [shouldUpdate, setShouldUpdate] = useState(false)
   const [needsRestart, setNeedsRestart] = useState(false)
   const [updateManifest, setUpdateManifest] = useState<
@@ -33,6 +33,7 @@ const UpdateNotifier: React.FC = () => {
     async function run() {
       if (process.env.NODE_ENV === 'production') {
         const updateStatus = await checkUpdate()
+
         setShouldUpdate(updateStatus.shouldUpdate)
         setUpdateManifest(updateStatus.manifest)
       }
@@ -135,4 +136,4 @@ const UpdateNotifier: React.FC = () => {
   )
 }
 
-export default UpdateNotifier
+export default TauriUpdateNotifier


### PR DESCRIPTION
Fixes external links, again

Also adds `TauriExternalLinkHandler`, which detects external links and opens them in the users default browser. This not only removes the need for `target="_blank"`, it also means links in the release notes open in a new window without even having to add that attribute.

This also bumps up the update notification to `index.tsx` from `app.tsx`. It's more "dependency" code than "application" code. And if something goes wrong at the application layer, the notification never shows. Technically more is still needed:

- Some kind of React error boundary
- Some kind of timer on the Tauri side of things. If the app fails to start in _some_ amount of time, present a dialog to the user to say "shit's broken" or something

## Preview

![Screenshot 2024-05-24 at 12 21 19 AM](https://github.com/mikew/wadpunk/assets/4729/9a781b15-3d67-4b3f-8afe-29b44936abef)
