### PR TITLE
fix: Fixes (2024-06-03)

### DIFF
--- a/src/sourcePorts/SourcePortsDialog.tsx
+++ b/src/sourcePorts/SourcePortsDialog.tsx
@@ -37,7 +37,8 @@ import SourcePortForm from './SourcePortForm'
 import { useSourcePortsContext } from './sourcePortsContext'
 
 const SourcePortsDialog: React.FC = () => {
-  const { sourcePorts, knownSourcePorts } = useSourcePortsContext()
+  const { sourcePorts, knownSourcePorts, defaultSourcePort } =
+    useSourcePortsContext()
   const isOpen = useRootSelector((state) => state.sourcePorts.isDialogOpen)
   const dispatch = useRootDispatch()
   const [createSourcePort] = useMutation(CreateSourcePortDocument)
@@ -121,7 +122,7 @@ const SourcePortsDialog: React.FC = () => {
                           }}
                         />
 
-                        {x.is_default ? (
+                        {x.id === defaultSourcePort?.id ? (
                           <Star color="action" fontSize="small" />
                         ) : undefined}
                       </ListItemButton>

--- a/src/tauri/TauriUpdateNotifier.tsx
+++ b/src/tauri/TauriUpdateNotifier.tsx
@@ -82,9 +82,9 @@ const TauriUpdateNotifier: React.FC = () => {
                   variant: 'error',
                 },
               )
-            }
 
-            setStatus('UPDATE_AVAILABLE')
+              setStatus('UPDATE_AVAILABLE')
+            }
           }}
         >
           {t('updateNotifier.actions.install')}


### PR DESCRIPTION
- Changes the criteria when showing which source port is the default. Since there's a concept of "implicit default source port", it's better to use that ID instead of whether the source port is marked as default or not
- Fixes a bug with the update install / reset button