### PR TITLE
fix: Window flicker on startup?

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           # linux-aarch64
           - ubuntu-22.04-arm
           # windows-x64
-          - windows-2019
+          - windows-2022
 
     runs-on: ${{ matrix.platform }}
 
@@ -184,7 +184,7 @@ jobs:
       # path.
       - run: |
           mkdir -p src-tauri/target/release/bundle
-          cp -rl wadpunk-windows-2019-X64/* src-tauri/target/release/bundle
+          cp -rl wadpunk-windows-2022-X64/* src-tauri/target/release/bundle
           cp -rl wadpunk-macos-13-X64/* src-tauri/target/release/bundle
           cp -rl wadpunk-macos-14-ARM64/* src-tauri/target/release/bundle
           cp -rl wadpunk-ubuntu-22.04-X64/* src-tauri/target/release/bundle

--- a/script/build
+++ b/script/build
@@ -3,7 +3,9 @@ set -ex
 
 rm -rf src-tauri/target/release/bundle
 
-./script/prepare-env
+if [ -z "$CI" ]; then
+  ./script/prepare-env
+fi
 
 ./node_modules/.bin/vite build
 ./node_modules/.bin/tauri build

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,7 +59,8 @@
         "title": "WADPunk",
         "theme": "Dark",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "visible": false
       }
     ],
 


### PR DESCRIPTION
This was to help with Steam Remote Play. When it would launch wadpunk and the window would resize, Steam would get confused and not adjust the region being streamed. This gets around that.

Seems Steam handles this better, but the change is still nice so I'm gonna merge it.