### PR TITLE
feat: Single instance

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4308,6 +4308,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d0e07b40fb2eb13778e30778f5979347a2bf30e1b9d47f78ff7fe92d2e4b3d"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.12",
+ "tracing",
+ "windows-sys 0.59.0",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4975,6 +4990,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4229,9 +4229,8 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-cli"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5458ae16eac81bdbe8d9da2a9f3e01e8cdedbc381cc1727c01127542c8a61c5"
+version = "2.2.1"
+source = "git+https://github.com/mikew/plugins-workspace?branch=cli-optional-args#8408ffb0372431624f2f163ba7ce57d9e6603d11"
 dependencies = [
  "clap",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.21.3"
 tauri-plugin-process = "2.2.1"
 tauri-plugin-shell = "2.2.1"
 tauri-plugin-opener = "2.2.7"
+tauri-plugin-single-instance = "2.2.4"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,9 @@ chrono = "0.4.41"
 plist = "1.7.2"
 tauri-plugin-window-state = "2"
 fs_extra = "1.3.0"
-tauri-plugin-cli = "2.2.0"
+# tauri-plugin-cli = "2.2.0"
+tauri-plugin-cli = { git = "https://github.com/mikew/plugins-workspace", branch = "cli-optional-args" }
+# tauri-plugin-cli = { path = "/Users/mike/Work/plugins-workspace/plugins/cli" }
 once_cell = "1.21.3"
 tauri-plugin-process = "2.2.1"
 tauri-plugin-shell = "2.2.1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,7 +2,9 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use tauri::Emitter;
 use tauri::Manager;
+use tauri_plugin_cli::CliExt;
 
 use graphql::datasource::DataSource;
 
@@ -27,13 +29,25 @@ fn main() {
       crate::tauri_legacy::set_app_handle(app.handle().clone());
       Ok(())
     })
-    .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+    .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
       #[cfg(desktop)]
       {
         let _ = app
           .get_webview_window("main")
           .expect("no main window")
           .set_focus();
+
+        let matches = app.cli().matches(Some(args));
+        match matches {
+          Ok(matches) => {
+            // TODO How to do this without serializing?
+            let serialized = serde_json::to_string(&matches).unwrap();
+            let _ = app.emit_to("main", "cli", serialized);
+          }
+          Err(e) => {
+            eprintln!("Error parsing CLI arguments: {}", e);
+          }
+        }
       }
     }))
     .plugin(tauri_plugin_window_state::Builder::default().build())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,8 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use tauri::Manager;
+
 use graphql::datasource::DataSource;
 
 mod database;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,9 +25,18 @@ fn main() {
       crate::tauri_legacy::set_app_handle(app.handle().clone());
       Ok(())
     })
-    .plugin(tauri_plugin_graphql::init(schema))
+    .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+      #[cfg(desktop)]
+      {
+        let _ = app
+          .get_webview_window("main")
+          .expect("no main window")
+          .set_focus();
+      }
+    }))
     .plugin(tauri_plugin_window_state::Builder::default().build())
     .plugin(tauri_plugin_opener::init())
+    .plugin(tauri_plugin_graphql::init(schema))
     .plugin(tauri_plugin_process::init())
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_cli::init())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,12 +51,14 @@ fn main() {
       }
     }))
     .plugin(tauri_plugin_window_state::Builder::default().build())
-    .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_graphql::init(schema))
+    .plugin(tauri_plugin_updater::Builder::new().build())
+
+    .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_process::init())
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_cli::init())
-    .plugin(tauri_plugin_updater::Builder::new().build())
+
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src/tauri/TauriCliHandler.tsx
+++ b/src/tauri/TauriCliHandler.tsx
@@ -1,3 +1,5 @@
+import { listen } from '@tauri-apps/api/event'
+import type { CliMatches } from '@tauri-apps/plugin-cli'
 import { getMatches } from '@tauri-apps/plugin-cli'
 import { useEffect } from 'react'
 
@@ -11,7 +13,8 @@ function TauriCliHandler() {
 
   useEffect(() => {
     async function run() {
-      const gameId = await getLaunchGameIdFromCli()
+      const matches = await getMatches()
+      const gameId = getLaunchGameIdFromCli(matches)
 
       if (!gameId) {
         return
@@ -24,11 +27,35 @@ function TauriCliHandler() {
     run()
   }, [dispatch, startGame])
 
+  useEffect(() => {
+    let unlisten: () => void = () => { }
+
+    async function run() {
+      unlisten = await listen<string>('cli', async (event) => {
+        const matches: CliMatches = JSON.parse(event.payload)
+
+        const gameId = getLaunchGameIdFromCli(matches)
+
+        if (!gameId) {
+          return
+        }
+
+        dispatch(actions.setSelectedId(gameId))
+        await startGame(gameId)
+      })
+    }
+
+    run()
+
+    return () => {
+      unlisten()
+    }
+  }, [dispatch, startGame])
+
   return null
 }
 
-async function getLaunchGameIdFromCli() {
-  const matches = await getMatches()
+function getLaunchGameIdFromCli(matches: CliMatches) {
   const launchGameCommand =
     matches.subcommand?.name === 'launch-game' ? matches.subcommand : null
 


### PR DESCRIPTION
Closes #29 

I'm not sure how I feel about this functionality now. Since users can now launch a game directly from the CLI, if they have one game launched that way, and try to launch another (come on, we've all had multiple games running launched from Steam before), I'm not sure what will happen. Definitely not what's expected.

Maybe this plugin can be the start of something better though. We can use it's callback to send an event to the window to re-parse cli args and launch the second game?