### PR TITLE
feat: URL Handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/api": "^2.5.0",
     "@tauri-apps/cli": "^2.5.0",
     "@tauri-apps/plugin-cli": "^2.2.0",
+    "@tauri-apps/plugin-deep-link": "^2.4.0",
     "@tauri-apps/plugin-opener": "^2.2.7",
     "@tauri-apps/plugin-process": "^2.2.1",
     "@tauri-apps/plugin-shell": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ devDependencies:
   '@tauri-apps/plugin-cli':
     specifier: ^2.2.0
     version: 2.2.0
+  '@tauri-apps/plugin-deep-link':
+    specifier: ^2.4.0
+    version: 2.4.0
   '@tauri-apps/plugin-opener':
     specifier: ^2.2.7
     version: 2.2.7
@@ -4145,6 +4148,10 @@ packages:
     resolution: {integrity: sha512-Ldux4ip+HGAcPUmuLT8EIkk6yafl5vK0P0c0byzAKzxJh7vxelVtdPONjfgTm96PbN24yjZNESY8CKo8qniluA==}
     dev: true
 
+  /@tauri-apps/api@2.6.0:
+    resolution: {integrity: sha512-hRNcdercfgpzgFrMXWwNDBN0B7vNzOzRepy6ZAmhxi5mDLVPNrTpo9MGg2tN/F7JRugj4d2aF7E1rtPXAHaetg==}
+    dev: true
+
   /@tauri-apps/cli-darwin-arm64@2.5.0:
     resolution: {integrity: sha512-VuVAeTFq86dfpoBDNYAdtQVLbP0+2EKCHIIhkaxjeoPARR0sLpFHz2zs0PcFU76e+KAaxtEtAJAXGNUc8E1PzQ==}
     engines: {node: '>= 10'}
@@ -4266,6 +4273,12 @@ packages:
     resolution: {integrity: sha512-rvNhMog9rHr01Xk+trBFKJ0eZICIvPkm9GX6ogB89/0hROU/lf+a/sb4vC0wtSeR7zrJuCSxwxYuvHCZheaYFA==}
     dependencies:
       '@tauri-apps/api': 2.5.0
+    dev: true
+
+  /@tauri-apps/plugin-deep-link@2.4.0:
+    resolution: {integrity: sha512-scFldWG5FDqLgbHauS5FtsE563Bo00sqYhhWTYwNzIOZFdOJtNY6tBqzqGJ8I1aehPtEVA0LcTNaq8fmDQbDGg==}
+    dependencies:
+      '@tauri-apps/api': 2.6.0
     dev: true
 
   /@tauri-apps/plugin-opener@2.2.7:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -67,56 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,39 +610,6 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
-
-[[package]]
-name = "clap"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -2070,12 +1987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,12 +2637,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "open"
@@ -4289,21 +4194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-cli"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e76101cc9848adfb6a04aae48a389062be457a785bb4349ae1423ddab5a82d"
-dependencies = [
- "clap",
- "log",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,6 +4287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.12",
  "tracing",
  "windows-sys 0.59.0",
@@ -5013,12 +4904,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5075,7 +4960,6 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
- "tauri-plugin-cli",
  "tauri-plugin-deep-link",
  "tauri-plugin-graphql",
  "tauri-plugin-opener",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -714,6 +714,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +821,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -997,6 +1023,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.102",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1672,6 +1707,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2711,6 +2752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3453,6 +3504,17 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
 ]
 
 [[package]]
@@ -4242,6 +4304,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab261eb006db10ab478e3fbb5a4e2692df3f7eb3e28300ee2b64428979167ed0"
+dependencies = [
+ "dunce",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result",
+]
+
+[[package]]
 name = "tauri-plugin-graphql"
 version = "3.1.1"
 source = "git+https://github.com/mikew/tauri-plugin-graphql?branch=tauri-2-latest#c29655d2c73e0ef83ed5629826588206c2384c03"
@@ -4562,6 +4644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4786,6 +4877,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4979,6 +5076,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-cli",
+ "tauri-plugin-deep-link",
  "tauri-plugin-graphql",
  "tauri-plugin-opener",
  "tauri-plugin-process",
@@ -5349,6 +5447,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4397,7 +4397,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
- "tauri-plugin-deep-link",
  "thiserror 2.0.12",
  "tracing",
  "windows-sys 0.59.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -67,6 +67,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +660,39 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -1987,6 +2070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,6 +2726,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "open"
@@ -4194,6 +4289,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-cli"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e76101cc9848adfb6a04aae48a389062be457a785bb4349ae1423ddab5a82d"
+dependencies = [
+ "clap",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4904,6 +5014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4960,6 +5076,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-cli",
  "tauri-plugin-deep-link",
  "tauri-plugin-graphql",
  "tauri-plugin-opener",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin-process = "2.2.1"
 tauri-plugin-shell = "2.2.1"
 tauri-plugin-opener = "2.2.7"
 tauri-plugin-single-instance = "2.2.4"
+tauri-plugin-deep-link = "2.4.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ chrono = "0.4.41"
 plist = "1.7.2"
 tauri-plugin-window-state = "2"
 fs_extra = "1.3.0"
-# tauri-plugin-cli = "2.3.0"
+tauri-plugin-cli = "2.3.0"
 # tauri-plugin-cli = { path = "/Users/mike/Work/plugins-workspace/plugins/cli" }
 once_cell = "1.21.3"
 tauri-plugin-process = "2.2.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.21.3"
 tauri-plugin-process = "2.2.1"
 tauri-plugin-shell = "2.2.1"
 tauri-plugin-opener = "2.2.7"
-tauri-plugin-single-instance = { version = "2.2.4", features = ["deep-link"] }
+tauri-plugin-single-instance = "2.2.4"
 tauri-plugin-deep-link = "2.4.0"
 
 [features]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,13 +22,13 @@ chrono = "0.4.41"
 plist = "1.7.2"
 tauri-plugin-window-state = "2"
 fs_extra = "1.3.0"
-tauri-plugin-cli = "2.3.0"
+# tauri-plugin-cli = "2.3.0"
 # tauri-plugin-cli = { path = "/Users/mike/Work/plugins-workspace/plugins/cli" }
 once_cell = "1.21.3"
 tauri-plugin-process = "2.2.1"
 tauri-plugin-shell = "2.2.1"
 tauri-plugin-opener = "2.2.7"
-tauri-plugin-single-instance = "2.2.4"
+tauri-plugin-single-instance = { version = "2.2.4", features = ["deep-link"] }
 tauri-plugin-deep-link = "2.4.0"
 
 [features]

--- a/src-tauri/capabilities/migrated.json
+++ b/src-tauri/capabilities/migrated.json
@@ -2,12 +2,9 @@
   "identifier": "migrated",
   "description": "permissions that were migrated from v1",
   "local": true,
-  "windows": [
-    "main"
-  ],
+  "windows": ["main"],
   "permissions": [
     "core:default",
-    "cli:allow-cli-matches",
     "process:default",
     "shell:default",
     "updater:default",

--- a/src-tauri/capabilities/migrated.json
+++ b/src-tauri/capabilities/migrated.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "cli:allow-cli-matches",
     "process:default",
     "shell:default",
     "updater:default",

--- a/src-tauri/capabilities/migrated.json
+++ b/src-tauri/capabilities/migrated.json
@@ -2,7 +2,9 @@
   "identifier": "migrated",
   "description": "permissions that were migrated from v1",
   "local": true,
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:default",
     "cli:allow-cli-matches",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,11 +27,11 @@ fn main() {
   tauri::Builder::default()
     .setup(|app| {
       crate::tauri_legacy::set_app_handle(app.handle().clone());
-			#[cfg(any(windows, target_os="linux"))]
-{
-use tauri_plugin_deep_link::DeepLinkExt;
-let _ = app.deep_link().register_all();
-}
+      #[cfg(any(windows, target_os="linux"))]
+      {
+        use tauri_plugin_deep_link::DeepLinkExt;
+        let _ = app.deep_link().register_all();
+      }
       Ok(())
     })
     .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -48,15 +48,17 @@ fn main() {
         }
       }
     }))
+    // break
     .plugin(tauri_plugin_window_state::Builder::default().build())
     .plugin(tauri_plugin_graphql::init(schema))
     .plugin(tauri_plugin_updater::Builder::new().build())
-
+    // break
     .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_process::init())
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_cli::init())
-
+    .plugin(tauri_plugin_deep_link::init())
+    // break
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -53,17 +53,17 @@ fn main() {
         }
       }
     }))
-    // break
+
     .plugin(tauri_plugin_window_state::Builder::default().build())
     .plugin(tauri_plugin_graphql::init(schema))
     .plugin(tauri_plugin_updater::Builder::new().build())
-    // break
+
     .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_process::init())
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_deep_link::init())
     .plugin(tauri_plugin_cli::init())
-    // break
+
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,7 @@
 
 use tauri::Emitter;
 use tauri::Manager;
-// use tauri_plugin_cli::CliExt;
+use tauri_plugin_cli::CliExt;
 
 use graphql::datasource::DataSource;
 
@@ -42,15 +42,15 @@ let _ = app.deep_link().register_all();
           .expect("no main window")
           .set_focus();
 
-        // let matches = app.cli().matches_from(args);
-        // match matches {
-        //   Ok(matches) => {
-        //     let _ = app.emit_to("main", "cli", matches);
-        //   }
-        //   Err(e) => {
-        //     eprintln!("Error parsing CLI arguments: {}", e);
-        //   }
-        // }
+        let matches = app.cli().matches_from(args);
+        match matches {
+          Ok(matches) => {
+            let _ = app.emit_to("main", "cli", matches);
+          }
+          Err(e) => {
+            eprintln!("Error parsing CLI arguments: {}", e);
+          }
+        }
       }
     }))
     // break
@@ -62,7 +62,7 @@ let _ = app.deep_link().register_all();
     .plugin(tauri_plugin_process::init())
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_deep_link::init())
-    // .plugin(tauri_plugin_cli::init())
+    .plugin(tauri_plugin_cli::init())
     // break
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,7 +4,7 @@
 
 use tauri::Emitter;
 use tauri::Manager;
-use tauri_plugin_cli::CliExt;
+// use tauri_plugin_cli::CliExt;
 
 use graphql::datasource::DataSource;
 
@@ -27,6 +27,11 @@ fn main() {
   tauri::Builder::default()
     .setup(|app| {
       crate::tauri_legacy::set_app_handle(app.handle().clone());
+			#[cfg(any(windows, target_os="linux"))]
+{
+use tauri_plugin_deep_link::DeepLinkExt;
+let _ = app.deep_link().register_all();
+}
       Ok(())
     })
     .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
@@ -37,15 +42,15 @@ fn main() {
           .expect("no main window")
           .set_focus();
 
-        let matches = app.cli().matches_from(args);
-        match matches {
-          Ok(matches) => {
-            let _ = app.emit_to("main", "cli", matches);
-          }
-          Err(e) => {
-            eprintln!("Error parsing CLI arguments: {}", e);
-          }
-        }
+        // let matches = app.cli().matches_from(args);
+        // match matches {
+        //   Ok(matches) => {
+        //     let _ = app.emit_to("main", "cli", matches);
+        //   }
+        //   Err(e) => {
+        //     eprintln!("Error parsing CLI arguments: {}", e);
+        //   }
+        // }
       }
     }))
     // break
@@ -56,8 +61,8 @@ fn main() {
     .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_process::init())
     .plugin(tauri_plugin_shell::init())
-    .plugin(tauri_plugin_cli::init())
     .plugin(tauri_plugin_deep_link::init())
+    // .plugin(tauri_plugin_cli::init())
     // break
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,7 +30,13 @@
       "longDescription": "",
       "beforeHelp": "",
       "afterHelp": "",
-      "args": [],
+      "args": [
+        {
+          "name": "potential-url",
+          "index": 1,
+          "takesValue": true
+        }
+      ],
       "subcommands": {
         "launch-game": {
           "args": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,8 @@
 {
   "bundle": {
-    "resources": ["./resources-arch-specific/*"],
+    "resources": [
+      "./resources-arch-specific/*"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -23,7 +25,9 @@
   "identifier": "com.mikewhy.wadpunk",
   "plugins": {
     "fs": {
-      "scope": ["$HOME/**"]
+      "scope": [
+        "$HOME/**"
+      ]
     },
     "cli": {
       "description": "",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,6 @@
 {
   "bundle": {
-    "resources": [
-      "./resources-arch-specific/*"
-    ],
+    "resources": ["./resources-arch-specific/*"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -25,9 +23,7 @@
   "identifier": "com.mikewhy.wadpunk",
   "plugins": {
     "fs": {
-      "scope": [
-        "$HOME/**"
-      ]
+      "scope": ["$HOME/**"]
     },
     "cli": {
       "description": "",
@@ -54,6 +50,11 @@
       ],
       "windows": {
         "installMode": "passive"
+      }
+    },
+    "deep-link": {
+      "desktop": {
+        "schemes": ["wadpunk"]
       }
     }
   },

--- a/src/tauri/TauriCliHandler.tsx
+++ b/src/tauri/TauriCliHandler.tsx
@@ -6,56 +6,68 @@ import { useEffect, useRef } from 'react'
 
 import { actions } from '#src/games/redux'
 import useStartGame from '#src/games/useStartGame'
+import useLatest from '#src/lib/useLatest'
 import { useRootDispatch } from '#src/redux/helpers'
+
+import type { WadpunkCliCommand } from './parseCli'
+import { parseCliMatchesToCommand, parseUrlToCommand } from './parseCli'
 
 function TauriCliHandler() {
   const { startGame } = useStartGame()
   const dispatch = useRootDispatch()
-  const didRun = useRef(false)
+  const didHandleBoot = useRef(false)
+
+  const handleCommand = useLatest((command: WadpunkCliCommand | undefined) => {
+    if (!command) {
+      return
+    }
+
+    switch (command.command) {
+      case 'launch-game': {
+        dispatch(actions.setSelectedId(command.gameId))
+        startGame(command.gameId)
+
+        break
+      }
+
+      default:
+        console.warn('Unknown command:', command)
+    }
+  })
 
   useEffect(() => {
     async function run() {
-      if (didRun.current) {
+      if (didHandleBoot.current) {
         return
       }
 
-      didRun.current = true
+      didHandleBoot.current = true
 
       const matches = await getMatches()
-      const gameId = getLaunchGameIdFromCli(matches)
-
-      if (!gameId) {
-        return
-      }
-
-      dispatch(actions.setSelectedId(gameId))
-      await startGame(gameId)
+      const command = parseCliMatchesToCommand(matches, true)
+      handleCommand.current(command)
     }
 
     run()
 
     return () => {
-      didRun.current = true
+      didHandleBoot.current = true
     }
-  }, [dispatch, startGame])
+  }, [dispatch, handleCommand, startGame])
 
   useEffect(() => {
     let listening = true
+    let unlisten: (() => void) | undefined = undefined
 
     async function run() {
-      await listen<CliMatches>('cli', async (event) => {
+      unlisten = await listen<CliMatches>('cli', async (event) => {
         if (!listening) {
           return
         }
 
-        const gameId = getLaunchGameIdFromCli(event.payload)
-
-        if (!gameId) {
-          return
-        }
-
-        dispatch(actions.setSelectedId(gameId))
-        await startGame(gameId)
+        // TODO Explain why we don't want url parsing here.
+        const command = parseCliMatchesToCommand(event.payload, false)
+        handleCommand.current(command)
       })
     }
 
@@ -63,59 +75,36 @@ function TauriCliHandler() {
 
     return () => {
       listening = false
+      unlisten?.()
     }
-  }, [dispatch, startGame])
+  }, [dispatch, handleCommand, startGame])
 
   useEffect(() => {
     let listening = true
+    let unlisten: (() => void) | undefined = undefined
 
-    onOpenUrl(async (urls) => {
-      if (!listening) {
-        return
-      }
-
-      for (const url of urls) {
-        const parsed = new URL(url)
-        console.log(parsed)
-        if (parsed.protocol !== 'wadpunk:') {
-          continue
+    async function run() {
+      unlisten = await onOpenUrl(async (urls) => {
+        if (!listening) {
+          return
         }
 
-        switch (parsed.host) {
-          case 'launch-game': {
-            const args = parsed.pathname.split('/').slice(1)
-            const gameId = args[0]
-
-            console.log(gameId)
-
-            if (gameId) {
-              dispatch(actions.setSelectedId(gameId))
-              startGame(gameId)
-            }
-          }
+        for (const url of urls) {
+          const command = parseUrlToCommand(url)
+          handleCommand.current(command)
         }
-      }
+      })
+    }
 
-      console.log(urls)
-    })
+    run()
 
     return () => {
       listening = false
+      unlisten?.()
     }
-  }, [dispatch, startGame])
+  }, [dispatch, handleCommand, startGame])
 
   return null
-}
-
-function getLaunchGameIdFromCli(matches: CliMatches) {
-  const launchGameCommand =
-    matches.subcommand?.name === 'launch-game' ? matches.subcommand : null
-
-  const gameId = launchGameCommand?.matches.args['game-id']?.value
-
-  if (typeof gameId === 'string') {
-    return gameId
-  }
 }
 
 export default TauriCliHandler

--- a/src/tauri/TauriCliHandler.tsx
+++ b/src/tauri/TauriCliHandler.tsx
@@ -65,7 +65,6 @@ function TauriCliHandler() {
           return
         }
 
-        // TODO Explain why we don't want url parsing here.
         const command = parseCliMatchesToCommand(event.payload, true)
         handleCommand.current(command)
       })

--- a/src/tauri/TauriCliHandler.tsx
+++ b/src/tauri/TauriCliHandler.tsx
@@ -66,7 +66,7 @@ function TauriCliHandler() {
         }
 
         // TODO Explain why we don't want url parsing here.
-        const command = parseCliMatchesToCommand(event.payload, false)
+        const command = parseCliMatchesToCommand(event.payload, true)
         handleCommand.current(command)
       })
     }

--- a/src/tauri/TauriCliHandler.tsx
+++ b/src/tauri/TauriCliHandler.tsx
@@ -1,6 +1,7 @@
 import { listen } from '@tauri-apps/api/event'
 import type { CliMatches } from '@tauri-apps/plugin-cli'
 import { getMatches } from '@tauri-apps/plugin-cli'
+import { onOpenUrl } from '@tauri-apps/plugin-deep-link'
 import { useEffect, useRef } from 'react'
 
 import { actions } from '#src/games/redux'
@@ -59,6 +60,44 @@ function TauriCliHandler() {
     }
 
     run()
+
+    return () => {
+      listening = false
+    }
+  }, [dispatch, startGame])
+
+  useEffect(() => {
+    let listening = true
+
+    onOpenUrl(async (urls) => {
+      if (!listening) {
+        return
+      }
+
+      for (const url of urls) {
+        const parsed = new URL(url)
+        console.log(parsed)
+        if (parsed.protocol !== 'wadpunk:') {
+          continue
+        }
+
+        switch (parsed.host) {
+          case 'launch-game': {
+            const args = parsed.pathname.split('/').slice(1)
+            const gameId = args[0]
+
+            console.log(gameId)
+
+            if (gameId) {
+              dispatch(actions.setSelectedId(gameId))
+              startGame(gameId)
+            }
+          }
+        }
+      }
+
+      console.log(urls)
+    })
 
     return () => {
       listening = false

--- a/src/tauri/parseCli.ts
+++ b/src/tauri/parseCli.ts
@@ -1,0 +1,74 @@
+import type { CliMatches } from '@tauri-apps/plugin-cli'
+
+export type WadpunkCliCommand = {
+  command: 'launch-game'
+  gameId: string
+}
+
+export function parseCliMatchesToCommand(
+  matches: CliMatches,
+  alsoHandleUrl = false,
+) {
+  if (alsoHandleUrl && matches.args['potential-url']?.value) {
+    const url = matches.args['potential-url'].value
+
+    if (typeof url === 'string') {
+      return parseUrlToCommand(url)
+    }
+  }
+
+  const subCommand = matches.subcommand?.name
+
+  switch (subCommand) {
+    case 'launch-game': {
+      const gameId = matches.subcommand?.matches.args['game-id']?.value
+
+      if (typeof gameId === 'string') {
+        const command: WadpunkCliCommand = {
+          command: 'launch-game',
+          gameId,
+        }
+
+        return command
+      }
+
+      break
+    }
+  }
+}
+
+export function parseUrlToCommand(url: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(url)
+  } catch (e) {
+    console.warn('Failed to parse URL:', url, e)
+    return
+  }
+
+  if (parsed.protocol !== 'wadpunk:') {
+    return
+  }
+
+  switch (parsed.host) {
+    case 'launch-game': {
+      const args = parsed.pathname.split('/').slice(1)
+      const gameId = args[0]
+
+      if (!gameId) {
+        return
+      }
+
+      const command: WadpunkCliCommand = {
+        command: 'launch-game',
+        gameId,
+      }
+
+      return command
+    }
+
+    default:
+      return
+  }
+}

--- a/src/tauri/parseCli.ts
+++ b/src/tauri/parseCli.ts
@@ -53,8 +53,7 @@ export function parseUrlToCommand(url: string) {
 
   switch (parsed.host) {
     case 'launch-game': {
-      const args = parsed.pathname.split('/').slice(1)
-      const gameId = args[0]
+      const gameId = parsed.pathname.slice(1)
 
       if (!gameId) {
         return

--- a/src/tauri/parseCli.ts
+++ b/src/tauri/parseCli.ts
@@ -53,7 +53,7 @@ export function parseUrlToCommand(url: string) {
 
   switch (parsed.host) {
     case 'launch-game': {
-      const gameId = parsed.pathname.slice(1)
+      const gameId = decodeURIComponent(parsed.pathname.slice(1))
 
       if (!gameId) {
         return


### PR DESCRIPTION
This adds support for `wadpunk://` URLs. Currently, there's only one valid one:

- `wadpunk://launch-game/some game/`

Since Tauri passes the URL as a CLI argument, I was able to handle both CLI and URLs by extending the CLI handler to also handle parsing URLs. So all these are equivalent:

- `xdg-open wadpunk://launch-game/freedoom1.wad`
- `open wadpunk://launch-game/freedoom1.wad`
- `start "" wadpunk://launch-game/freedoom1.wad`
- `/path/to/wadpunk launch-game freedoom1.wad`

Closes #113 

## Preview


https://github.com/user-attachments/assets/00e9bfca-b13a-4f5b-86d6-fe91a6daa9fc

